### PR TITLE
Add unified number parsing functions in sources

### DIFF
--- a/built_in_fields.go
+++ b/built_in_fields.go
@@ -53,9 +53,31 @@ func newField(dest interface{}, sourcesLen int, callback func(sourceNum int) val
 	return f
 }
 
-func NewInt64Field(dest *int64, sources ...Int64ValueBinding) Field {
+func NewInt64Field(dest *int64, sources ...IntValueBinding) Field {
 	return newField(dest, len(sources), func(sourceNum int) valueBinding {
-		return vb(sources[sourceNum], sources[sourceNum].BindInt64ValueTo(dest))
+		binding := sources[sourceNum].BindIntValue()
+		return vb(sources[sourceNum], func() error {
+			val, err := binding(64)
+			if err != nil {
+				return err
+			}
+			*dest = val
+			return nil
+		})
+	})
+}
+
+func NewInt8Field(dest *int8, sources ...IntValueBinding) Field {
+	return newField(dest, len(sources), func(sourceNum int) valueBinding {
+		binding := sources[sourceNum].BindIntValue()
+		return vb(sources[sourceNum], func() error {
+			val, err := binding(8)
+			if err != nil {
+				return err
+			}
+			*dest = int8(val) // this is safe
+			return nil
+		})
 	})
 }
 

--- a/built_in_fields_test.go
+++ b/built_in_fields_test.go
@@ -34,7 +34,7 @@ var testCaseGroups = []testCaseGroup{ //nolint:gochecknoglobals
 			var dest int64
 			return NewInt64Field(
 				&dest,
-				DefaultInt64Value(1),
+				DefaultIntValue(1),
 				sources.json.From("vus"),
 				sources.env.From("K6_VUS"),
 				sources.cli.FromNameAndShorthand("vus", "u"),
@@ -47,7 +47,7 @@ var testCaseGroups = []testCaseGroup{ //nolint:gochecknoglobals
 			{
 				json: `{"vus": "foo"}`,
 				// TODO: improve this error message, something like `"foo" is not a valid integer value` would be much better
-				expectedErrors: []string{"json: cannot unmarshal string into Go value of type int64"},
+				expectedErrors: []string{`strconv.ParseInt: parsing "\"foo\"": invalid syntax`},
 			},
 			{
 				json:          `{"vus": 2}`,
@@ -67,7 +67,7 @@ var testCaseGroups = []testCaseGroup{ //nolint:gochecknoglobals
 				json: `{"vus": "foo"}`,
 				env:  []string{"K6_VUS=bar"},
 				expectedErrors: []string{ // TODO: better error messages
-					`json: cannot unmarshal string into Go value of type int64`,
+					`strconv.ParseInt: parsing "\"foo\"": invalid syntax`,
 					`strconv.ParseInt: parsing "bar": invalid syntax`,
 				},
 			},
@@ -99,6 +99,47 @@ var testCaseGroups = []testCaseGroup{ //nolint:gochecknoglobals
 				expectedValue: "foo",
 			},
 			// TODO: add more test cases for this field
+		},
+	},
+	{
+		name: "int8 default",
+		field: func(sources testSources) Field {
+			var dest int8
+			return NewInt8Field(
+				&dest,
+				DefaultIntValue(129),
+			)
+		},
+		testCases: []fieldTestCase{
+			{
+				expectedErrors: []string{"invalid value 129, has to be between -128 and 127"},
+			},
+		},
+	},
+	{
+		name: "int8 field",
+		field: func(sources testSources) Field {
+			var dest int8
+			return NewInt8Field(
+				&dest,
+				DefaultIntValue(127),
+				sources.json.From("tiny"),
+				sources.env.From("K6_TINY"),
+				sources.cli.FromName("tiny"),
+			)
+		},
+		testCases: []fieldTestCase{
+			{
+				expectedValue: int8(127),
+			},
+			{
+				json:          `{"tiny": -128}`,
+				expectedValue: int8(-128),
+			},
+			{
+				cli:            []string{"--tiny=-129"},
+				expectedErrors: []string{`strconv.ParseInt: parsing "-129": value out of range`}, // TODO: better error message
+			},
 		},
 	},
 	{

--- a/example/conf_script.go
+++ b/example/conf_script.go
@@ -20,6 +20,8 @@ type ScriptConfig struct {
 		Server string
 	}
 
+	Tiny int8
+
 	Scenarios1 lib.ScenarioConfigs
 
 	Scenarios2 lib.ScenarioConfigs
@@ -54,7 +56,7 @@ func NewScriptConfig(
 
 	cm.AddField(croconf.NewInt64Field(
 		&conf.VUs,
-		croconf.DefaultInt64Value(1),
+		croconf.DefaultIntValue(1),
 		jsonSource.From("vus"),
 		envVarsSource.From("K6_VUS"),
 		cliSource.FromNameAndShorthand("vus", "u"),
@@ -79,6 +81,14 @@ func NewScriptConfig(
 		&conf.DNS.Server,
 		croconf.DefaultStringValue("8.8.8.8"),
 		jsonSource.From("dns").From("server"),
+	))
+
+	cm.AddField(croconf.NewInt8Field(
+		&conf.Tiny,
+		croconf.DefaultIntValue(1),
+		jsonSource.From("tiny"),
+		envVarsSource.From("K6_TINY"),
+		cliSource.FromName("tiny"),
 	))
 
 	// This is one way to add a custom field in a type-safe manner:

--- a/example/config.json
+++ b/example/config.json
@@ -16,6 +16,7 @@
         "ttl": "6500ms",
         "server": "1.1.1.1"
     },
+    "tiny": 127,
     "scenarios1": {
         "contacts": {
             "executor": "ramping-vus",

--- a/source_defaults.go
+++ b/source_defaults.go
@@ -1,6 +1,9 @@
 package croconf
 
-import "encoding"
+import (
+	"encoding"
+	"fmt"
+)
 
 // TODO: make more flexible with callbacks, so that besides defaut values, we
 // can use these for custom wrappers as well?
@@ -31,21 +34,26 @@ func DefaultStringValue(s string) interface {
 	return defaultStringValue(s)
 }
 
-type defaultInt64Value int64
+type defaultIntValue int64
 
-func (div defaultInt64Value) BindInt64ValueTo(dest *int64) func() error {
-	return func() error {
-		*dest = int64(div)
-		return nil
+func (div defaultIntValue) BindIntValue() func(bitSize int) (int64, error) {
+	return func(bitSize int) (int64, error) {
+		val := int64(div)
+		// See https://golang.org/pkg/math/#pkg-constants
+		min, max := int64(-1<<(bitSize-1)), int64(1<<(bitSize-1)-1)
+		if val < min || val > max {
+			return 0, fmt.Errorf("invalid value %d, has to be between %d and %d", val, min, max)
+		}
+		return val, nil
 	}
 }
 
-func (div defaultInt64Value) GetSource() Source {
+func (div defaultIntValue) GetSource() Source {
 	return nil
 }
 
-func DefaultInt64Value(i int64) Int64ValueBinding {
-	return defaultInt64Value(i)
+func DefaultIntValue(i int64) IntValueBinding {
+	return defaultIntValue(i)
 }
 
 type DefaultCustomValue func()

--- a/source_env_vars.go
+++ b/source_env_vars.go
@@ -55,18 +55,13 @@ func (eb *envBinding) BindStringValueTo(dest *string) func() error {
 	}
 }
 
-func (eb *envBinding) BindInt64ValueTo(dest *int64) func() error {
-	return func() error {
+func (eb *envBinding) BindIntValue() func(bitSize int) (int64, error) {
+	return func(bitSize int) (int64, error) {
 		val, ok := eb.source.env[eb.name]
 		if !ok {
-			return ErrorMissing // TODO: better error message, e.g. 'field %s is not present in %s'?
+			return 0, ErrorMissing // TODO: better error message, e.g. 'field %s is not present in %s'?
 		}
-		intVal, err := strconv.ParseInt(val, 10, 64) // TODO: use a custom function with better error message
-		if err != nil {
-			return err
-		}
-		*dest = intVal
-		return nil
+		return strconv.ParseInt(val, 10, bitSize) // TODO: use a custom function with better error messages
 	}
 }
 

--- a/source_json.go
+++ b/source_json.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 // TODO: use json.Decoder for this? json.Unmarshal() is a bit too magical
@@ -102,14 +103,15 @@ func (jb *jsonBinding) BindStringValueTo(dest *string) func() error {
 	}
 }
 
-func (jb *jsonBinding) BindInt64ValueTo(dest *int64) func() error {
-	return func() error {
+func (jb *jsonBinding) BindIntValue() func(bitSize int) (int64, error) {
+	return func(bitSize int) (int64, error) {
 		raw, err := jb.lookup()
 		if err != nil {
-			return err
+			return 0, err
 		}
 
-		return json.Unmarshal(raw, dest) // TODO: less reflection, better error messages
+		// TODO: use a custom parser for better error messages
+		return strconv.ParseInt(string(raw), 10, bitSize)
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -23,20 +23,10 @@ type SourceGetter interface {
 type LazySingleValueBinding interface {
 	SourceGetter
 	StringValueBinding
-	// TODO: all all other types
-	/*
-		UintValueBinding
-		Uint8ValueBinding
-		Uint16ValueBinding
-		Uint32ValueBinding
-		Uint64ValueBinding
-		IntValueBinding
-		Int8ValueBinding
-		Int16ValueBinding
-		Int32ValueBinding
-		...
-	*/
-	Int64ValueBinding
+	IntValueBinding
+	// TODO: uncomment when we implement them
+	// UintValueBinding
+	// FloatValueBinding
 	TextBasedValueBinding
 }
 
@@ -45,9 +35,19 @@ type StringValueBinding interface {
 	BindStringValueTo(dest *string) func() error
 }
 
-type Int64ValueBinding interface {
+type IntValueBinding interface {
 	SourceGetter
-	BindInt64ValueTo(dest *int64) func() error
+	BindIntValue() func(bitSize int) (int64, error)
+}
+
+type UintValueBinding interface {
+	SourceGetter
+	BindUintValue() func(bitSize int) (uint64, error)
+}
+
+type FloatValueBinding interface {
+	SourceGetter
+	BindFloatValue() func(bitSize int) (float64, error)
 }
 
 type TextBasedValueBinding interface {


### PR DESCRIPTION
This preserves the completely type-safe "frontends" (i.e. `Field` constructors like `NewInt64Field(dest *int64, ...)`), but makes the job of implementing a `Source` much simpler. By using the biggest types, we don't need to implement a method for every single base Go number type (int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, byte, float32, float64), instead just 3 (int64, uint64, float64) and some extra validation. 