### PR TITLE
Binding refactoring

### DIFF
--- a/built_in_fields.go
+++ b/built_in_fields.go
@@ -70,7 +70,7 @@ func newField(dest interface{}, sourcesLen int, callback func(sourceNum int) val
 	return f
 }
 
-func intValHelper(sources []IntValueBinding, bitSize int, saveToDest func(int64)) func(sourceNum int) valueBinding {
+func intValHelper(sources []IntValueBinder, bitSize int, saveToDest func(int64)) func(sourceNum int) valueBinding {
 	return func(sourceNum int) valueBinding {
 		var val int64
 		bind := sources[sourceNum].BindIntValueTo(&val)
@@ -87,37 +87,37 @@ func intValHelper(sources []IntValueBinding, bitSize int, saveToDest func(int64)
 	}
 }
 
-func NewIntField(dest *int, sources ...IntValueBinding) Field {
+func NewIntField(dest *int, sources ...IntValueBinder) Field {
 	return newField(dest, len(sources), intValHelper(sources, strconv.IntSize, func(val int64) {
 		*dest = int(val) // this is safe, intValHelper checks val against bitSize
 	}))
 }
 
-func NewInt8Field(dest *int8, sources ...IntValueBinding) Field {
+func NewInt8Field(dest *int8, sources ...IntValueBinder) Field {
 	return newField(dest, len(sources), intValHelper(sources, 8, func(val int64) {
 		*dest = int8(val) // this is safe, intValHelper checks val against bitSize
 	}))
 }
 
-func NewInt16Field(dest *int16, sources ...IntValueBinding) Field {
+func NewInt16Field(dest *int16, sources ...IntValueBinder) Field {
 	return newField(dest, len(sources), intValHelper(sources, 16, func(val int64) {
 		*dest = int16(val) // this is safe, intValHelper checks val against bitSize
 	}))
 }
 
-func NewInt32Field(dest *int32, sources ...IntValueBinding) Field {
+func NewInt32Field(dest *int32, sources ...IntValueBinder) Field {
 	return newField(dest, len(sources), intValHelper(sources, 32, func(val int64) {
 		*dest = int32(val) // this is safe, intValHelper checks val against bitSize
 	}))
 }
 
-func NewInt64Field(dest *int64, sources ...IntValueBinding) Field {
+func NewInt64Field(dest *int64, sources ...IntValueBinder) Field {
 	return newField(dest, len(sources), func(sourceNum int) valueBinding {
 		return vb(sources[sourceNum], sources[sourceNum].BindIntValueTo(dest))
 	})
 }
 
-func NewInt8SliceField(dest *[]int8, sources ...ArrayBinding) Field {
+func NewInt8SliceField(dest *[]int8, sources ...ArrayBinder) Field {
 	// TODO: figure out some way to avoid the boilerplate?
 	return newField(dest, len(sources), func(sourceNum int) valueBinding {
 		source := sources[sourceNum]
@@ -147,7 +147,7 @@ func NewInt8SliceField(dest *[]int8, sources ...ArrayBinding) Field {
 	})
 }
 
-func NewInt64SliceField(dest *[]int64, sources ...ArrayBinding) Field {
+func NewInt64SliceField(dest *[]int64, sources ...ArrayBinder) Field {
 	return newField(dest, len(sources), func(sourceNum int) valueBinding {
 		source := sources[sourceNum]
 		arrBind := source.BindArray()
@@ -173,25 +173,25 @@ func NewInt64SliceField(dest *[]int64, sources ...ArrayBinding) Field {
 	})
 }
 
-func NewStringField(dest *string, sources ...StringValueBinding) Field {
+func NewStringField(dest *string, sources ...StringValueBinder) Field {
 	return newField(dest, len(sources), func(sourceNum int) valueBinding {
 		return vb(sources[sourceNum], sources[sourceNum].BindStringValueTo(dest))
 	})
 }
 
-func NewTextBasedField(dest encoding.TextUnmarshaler, sources ...TextBasedValueBinding) Field {
+func NewTextBasedField(dest encoding.TextUnmarshaler, sources ...TextBasedValueBinder) Field {
 	return newField(dest, len(sources), func(sourceNum int) valueBinding {
 		return vb(sources[sourceNum], sources[sourceNum].BindTextBasedValueTo(dest))
 	})
 }
 
-func NewBoolField(dest *bool, sources ...BoolValueBinding) Field {
+func NewBoolField(dest *bool, sources ...BoolValueBinder) Field {
 	return newField(dest, len(sources), func(sourceNum int) valueBinding {
 		return vb(sources[sourceNum], sources[sourceNum].BindBoolValueTo(dest))
 	})
 }
 
-func NewCustomField(dest interface{}, sources ...CustomValueBinding) Field {
+func NewCustomField(dest interface{}, sources ...CustomValueBinder) Field {
 	return newField(dest, len(sources), func(sourceNum int) valueBinding {
 		return vb(sources[sourceNum], sources[sourceNum].BindValue())
 	})

--- a/built_in_fields.go
+++ b/built_in_fields.go
@@ -2,7 +2,6 @@ package croconf
 
 import (
 	"encoding"
-	"strconv"
 )
 
 type field struct {
@@ -30,54 +29,6 @@ func newField(dest interface{}, sourcesLen int, callback func(sourceNum int) Bin
 	return f
 }
 
-func intValHelper(sources []IntValueBinder, bitSize int, saveToDest func(int64)) func(sourceNum int) Binding {
-	return func(sourceNum int) Binding {
-		var val int64
-		binding := sources[sourceNum].BindIntValueTo(&val)
-
-		return wrapBinding(binding, func() error {
-			if err := binding.Apply(); err != nil {
-				return err
-			}
-			if err := checkIntBitsize(val, bitSize); err != nil {
-				return err
-			}
-			saveToDest(val)
-			return nil
-		})
-	}
-}
-
-func NewIntField(dest *int, sources ...IntValueBinder) Field {
-	return newField(dest, len(sources), intValHelper(sources, strconv.IntSize, func(val int64) {
-		*dest = int(val) // this is safe, intValHelper checks val against bitSize
-	}))
-}
-
-func NewInt8Field(dest *int8, sources ...IntValueBinder) Field {
-	return newField(dest, len(sources), intValHelper(sources, 8, func(val int64) {
-		*dest = int8(val) // this is safe, intValHelper checks val against bitSize
-	}))
-}
-
-func NewInt16Field(dest *int16, sources ...IntValueBinder) Field {
-	return newField(dest, len(sources), intValHelper(sources, 16, func(val int64) {
-		*dest = int16(val) // this is safe, intValHelper checks val against bitSize
-	}))
-}
-
-func NewInt32Field(dest *int32, sources ...IntValueBinder) Field {
-	return newField(dest, len(sources), intValHelper(sources, 32, func(val int64) {
-		*dest = int32(val) // this is safe, intValHelper checks val against bitSize
-	}))
-}
-
-func NewInt64Field(dest *int64, sources ...IntValueBinder) Field {
-	return newField(dest, len(sources), func(sourceNum int) Binding {
-		return sources[sourceNum].BindIntValueTo(dest)
-	})
-}
-
 type arrayHandler func(arrLength int, getElement func(int) LazySingleValueBinder) error
 
 func newArrayField(dest interface{}, sources []ArrayValueBinder, handler arrayHandler) Field {
@@ -94,96 +45,6 @@ func newArrayField(dest interface{}, sources []ArrayValueBinder, handler arrayHa
 			return handler(arrLength, getElement)
 		})
 	})
-}
-
-func intSliceHandler(newTypedSlice func(int) (add func(int64) error, save func())) arrayHandler {
-	return func(arrLength int, getElement func(int) LazySingleValueBinder) error {
-		add, save := newTypedSlice(arrLength)
-		for i := 0; i < arrLength; i++ {
-			var val int64
-			elBinding := getElement(i).BindIntValueTo(&val)
-			if err := elBinding.Apply(); err != nil {
-				return err
-			}
-			if err := add(val); err != nil {
-				return err
-			}
-		}
-		save()
-		return nil
-	}
-}
-
-func NewIntSliceField(dest *[]int, sources ...ArrayValueBinder) Field {
-	return newArrayField(dest, sources, intSliceHandler(func(arrLength int) (func(int64) error, func()) {
-		newArr := make([]int, 0, arrLength)
-		add := func(val int64) error {
-			if err := checkIntBitsize(val, strconv.IntSize); err != nil {
-				return err
-			}
-			newArr = append(newArr, int(val)) // this is safe
-			return nil
-		}
-		save := func() { *dest = newArr }
-		return add, save
-	}))
-}
-
-func NewInt8SliceField(dest *[]int8, sources ...ArrayValueBinder) Field {
-	return newArrayField(dest, sources, intSliceHandler(func(arrLength int) (func(int64) error, func()) {
-		newArr := make([]int8, 0, arrLength)
-		add := func(val int64) error {
-			if err := checkIntBitsize(val, 8); err != nil {
-				return err
-			}
-			newArr = append(newArr, int8(val)) // this is safe
-			return nil
-		}
-		save := func() { *dest = newArr }
-		return add, save
-	}))
-}
-
-func NewInt16SliceField(dest *[]int16, sources ...ArrayValueBinder) Field {
-	return newArrayField(dest, sources, intSliceHandler(func(arrLength int) (func(int64) error, func()) {
-		newArr := make([]int16, 0, arrLength)
-		add := func(val int64) error {
-			if err := checkIntBitsize(val, 16); err != nil {
-				return err
-			}
-			newArr = append(newArr, int16(val)) // this is safe
-			return nil
-		}
-		save := func() { *dest = newArr }
-		return add, save
-	}))
-}
-
-func NewInt32SliceField(dest *[]int32, sources ...ArrayValueBinder) Field {
-	return newArrayField(dest, sources, intSliceHandler(func(arrLength int) (func(int64) error, func()) {
-		newArr := make([]int32, 0, arrLength)
-		add := func(val int64) error {
-			if err := checkIntBitsize(val, 32); err != nil {
-				return err
-			}
-			newArr = append(newArr, int32(val)) // this is safe
-			return nil
-		}
-		save := func() { *dest = newArr }
-		return add, save
-	}))
-}
-
-func NewInt64SliceField(dest *[]int64, sources ...ArrayValueBinder) Field {
-	return newArrayField(dest, sources, intSliceHandler(func(arrLength int) (func(int64) error, func()) {
-		newArr := make([]int64, 0, arrLength)
-		add := func(val int64) error {
-			newArr = append(newArr, val)
-			return nil
-		}
-		save := func() { *dest = newArr }
-		return add, save
-	}))
 }
 
 func NewStringField(dest *string, sources ...StringValueBinder) Field {

--- a/built_in_fields_ints.go
+++ b/built_in_fields_ints.go
@@ -1,0 +1,141 @@
+package croconf //nolint:dupl
+
+import "strconv"
+
+func intValHelper(sources []IntValueBinder, bitSize int, saveToDest func(int64)) func(sourceNum int) Binding {
+	return func(sourceNum int) Binding {
+		var val int64
+		binding := sources[sourceNum].BindIntValueTo(&val)
+
+		return wrapBinding(binding, func() error {
+			if err := binding.Apply(); err != nil {
+				return err
+			}
+			if err := checkIntBitsize(val, bitSize); err != nil {
+				return err
+			}
+			saveToDest(val)
+			return nil
+		})
+	}
+}
+
+func NewIntField(dest *int, sources ...IntValueBinder) Field {
+	return newField(dest, len(sources), intValHelper(sources, strconv.IntSize, func(val int64) {
+		*dest = int(val) // this is safe, intValHelper checks val against bitSize
+	}))
+}
+
+func NewInt8Field(dest *int8, sources ...IntValueBinder) Field {
+	return newField(dest, len(sources), intValHelper(sources, 8, func(val int64) {
+		*dest = int8(val) // this is safe, intValHelper checks val against bitSize
+	}))
+}
+
+func NewInt16Field(dest *int16, sources ...IntValueBinder) Field {
+	return newField(dest, len(sources), intValHelper(sources, 16, func(val int64) {
+		*dest = int16(val) // this is safe, intValHelper checks val against bitSize
+	}))
+}
+
+func NewInt32Field(dest *int32, sources ...IntValueBinder) Field {
+	return newField(dest, len(sources), intValHelper(sources, 32, func(val int64) {
+		*dest = int32(val) // this is safe, intValHelper checks val against bitSize
+	}))
+}
+
+func NewInt64Field(dest *int64, sources ...IntValueBinder) Field {
+	return newField(dest, len(sources), func(sourceNum int) Binding {
+		return sources[sourceNum].BindIntValueTo(dest)
+	})
+}
+
+func intSliceHandler(newTypedSlice func(int) (add func(int64) error, save func())) arrayHandler {
+	return func(arrLength int, getElement func(int) LazySingleValueBinder) error {
+		add, save := newTypedSlice(arrLength)
+		for i := 0; i < arrLength; i++ {
+			var val int64
+			elBinding := getElement(i).BindIntValueTo(&val)
+			if err := elBinding.Apply(); err != nil {
+				return err
+			}
+			if err := add(val); err != nil {
+				return err
+			}
+		}
+		save()
+		return nil
+	}
+}
+
+func NewIntSliceField(dest *[]int, sources ...ArrayValueBinder) Field {
+	return newArrayField(dest, sources, intSliceHandler(func(arrLength int) (func(int64) error, func()) {
+		newArr := make([]int, 0, arrLength)
+		add := func(val int64) error {
+			if err := checkIntBitsize(val, strconv.IntSize); err != nil {
+				return err
+			}
+			newArr = append(newArr, int(val)) // this is safe
+			return nil
+		}
+		save := func() { *dest = newArr }
+		return add, save
+	}))
+}
+
+func NewInt8SliceField(dest *[]int8, sources ...ArrayValueBinder) Field {
+	return newArrayField(dest, sources, intSliceHandler(func(arrLength int) (func(int64) error, func()) {
+		newArr := make([]int8, 0, arrLength)
+		add := func(val int64) error {
+			if err := checkIntBitsize(val, 8); err != nil {
+				return err
+			}
+			newArr = append(newArr, int8(val)) // this is safe
+			return nil
+		}
+		save := func() { *dest = newArr }
+		return add, save
+	}))
+}
+
+func NewInt16SliceField(dest *[]int16, sources ...ArrayValueBinder) Field {
+	return newArrayField(dest, sources, intSliceHandler(func(arrLength int) (func(int64) error, func()) {
+		newArr := make([]int16, 0, arrLength)
+		add := func(val int64) error {
+			if err := checkIntBitsize(val, 16); err != nil {
+				return err
+			}
+			newArr = append(newArr, int16(val)) // this is safe
+			return nil
+		}
+		save := func() { *dest = newArr }
+		return add, save
+	}))
+}
+
+func NewInt32SliceField(dest *[]int32, sources ...ArrayValueBinder) Field {
+	return newArrayField(dest, sources, intSliceHandler(func(arrLength int) (func(int64) error, func()) {
+		newArr := make([]int32, 0, arrLength)
+		add := func(val int64) error {
+			if err := checkIntBitsize(val, 32); err != nil {
+				return err
+			}
+			newArr = append(newArr, int32(val)) // this is safe
+			return nil
+		}
+		save := func() { *dest = newArr }
+		return add, save
+	}))
+}
+
+func NewInt64SliceField(dest *[]int64, sources ...ArrayValueBinder) Field {
+	return newArrayField(dest, sources, intSliceHandler(func(arrLength int) (func(int64) error, func()) {
+		newArr := make([]int64, 0, arrLength)
+		add := func(val int64) error {
+			newArr = append(newArr, val)
+			return nil
+		}
+		save := func() { *dest = newArr }
+		return add, save
+	}))
+}

--- a/built_in_fields_test.go
+++ b/built_in_fields_test.go
@@ -112,7 +112,7 @@ var testCaseGroups = []testCaseGroup{ //nolint:gochecknoglobals
 		},
 		testCases: []fieldTestCase{
 			{
-				expectedErrors: []string{"invalid value 129, has to be between -128 and 127"},
+				expectedErrors: []string{"invalid value 129, it must be between -128 and 127"},
 			},
 		},
 	},
@@ -138,7 +138,7 @@ var testCaseGroups = []testCaseGroup{ //nolint:gochecknoglobals
 			},
 			{
 				cli:            []string{"--tiny=-129"},
-				expectedErrors: []string{`BindIntValue: parsing "-129": value out of range`}, // TODO: better error message
+				expectedErrors: []string{`invalid value -129, it must be between -128 and 127`},
 			},
 		},
 	},
@@ -259,7 +259,7 @@ var testCaseGroups = []testCaseGroup{ //nolint:gochecknoglobals
 			{
 				json: `{"tinyArr": [1, 255]}`,
 				expectedErrors: []string{
-					`BindIntValue: parsing "255": value out of range`, // TODO: better error
+					`invalid value 255, it must be between -128 and 127`,
 				},
 			},
 		},

--- a/built_in_fields_test.go
+++ b/built_in_fields_test.go
@@ -332,7 +332,8 @@ func runTestCase(t *testing.T, tcg testCaseGroup, tc fieldTestCase) {
 		}
 	}
 
-	errs := field.Consolidate()
+	mf := &ManagedField{Field: field}
+	errs := mf.Consolidate()
 	if len(tc.expectedErrors) != len(errs) {
 		t.Fatalf("Expected %d errors but got %d: %#v", len(tc.expectedErrors), len(errs), errs)
 	}

--- a/built_in_fields_uints.go
+++ b/built_in_fields_uints.go
@@ -1,0 +1,141 @@
+package croconf //nolint:dupl
+
+import "strconv"
+
+func uintValHelper(sources []UintValueBinder, bitSize int, saveToDest func(uint64)) func(sourceNum int) Binding {
+	return func(sourceNum int) Binding {
+		var val uint64
+		binding := sources[sourceNum].BindUintValueTo(&val)
+
+		return wrapBinding(binding, func() error {
+			if err := binding.Apply(); err != nil {
+				return err
+			}
+			if err := checkUintBitsize(val, bitSize); err != nil {
+				return err
+			}
+			saveToDest(val)
+			return nil
+		})
+	}
+}
+
+func NewUintField(dest *uint, sources ...UintValueBinder) Field {
+	return newField(dest, len(sources), uintValHelper(sources, strconv.IntSize, func(val uint64) {
+		*dest = uint(val) // this is safe, uintValHelper checks val against bitSize
+	}))
+}
+
+func NewUint8Field(dest *uint8, sources ...UintValueBinder) Field {
+	return newField(dest, len(sources), uintValHelper(sources, 8, func(val uint64) {
+		*dest = uint8(val) // this is safe, uintValHelper checks val against bitSize
+	}))
+}
+
+func NewUint16Field(dest *uint16, sources ...UintValueBinder) Field {
+	return newField(dest, len(sources), uintValHelper(sources, 16, func(val uint64) {
+		*dest = uint16(val) // this is safe, uintValHelper checks val against bitSize
+	}))
+}
+
+func NewUint32Field(dest *uint32, sources ...UintValueBinder) Field {
+	return newField(dest, len(sources), uintValHelper(sources, 32, func(val uint64) {
+		*dest = uint32(val) // this is safe, uintValHelper checks val against bitSize
+	}))
+}
+
+func NewUint64Field(dest *uint64, sources ...UintValueBinder) Field {
+	return newField(dest, len(sources), func(sourceNum int) Binding {
+		return sources[sourceNum].BindUintValueTo(dest)
+	})
+}
+
+func uintSliceHandler(newTypedSlice func(int) (add func(uint64) error, save func())) arrayHandler {
+	return func(arrLength int, getElement func(int) LazySingleValueBinder) error {
+		add, save := newTypedSlice(arrLength)
+		for i := 0; i < arrLength; i++ {
+			var val uint64
+			elBinding := getElement(i).BindUintValueTo(&val)
+			if err := elBinding.Apply(); err != nil {
+				return err
+			}
+			if err := add(val); err != nil {
+				return err
+			}
+		}
+		save()
+		return nil
+	}
+}
+
+func NewUintSliceField(dest *[]uint, sources ...ArrayValueBinder) Field {
+	return newArrayField(dest, sources, uintSliceHandler(func(arrLength int) (func(uint64) error, func()) {
+		newArr := make([]uint, 0, arrLength)
+		add := func(val uint64) error {
+			if err := checkUintBitsize(val, strconv.IntSize); err != nil {
+				return err
+			}
+			newArr = append(newArr, uint(val)) // this is safe
+			return nil
+		}
+		save := func() { *dest = newArr }
+		return add, save
+	}))
+}
+
+func NewUint8SliceField(dest *[]uint8, sources ...ArrayValueBinder) Field {
+	return newArrayField(dest, sources, uintSliceHandler(func(arrLength int) (func(uint64) error, func()) {
+		newArr := make([]uint8, 0, arrLength)
+		add := func(val uint64) error {
+			if err := checkUintBitsize(val, 8); err != nil {
+				return err
+			}
+			newArr = append(newArr, uint8(val)) // this is safe
+			return nil
+		}
+		save := func() { *dest = newArr }
+		return add, save
+	}))
+}
+
+func NewUint16SliceField(dest *[]uint16, sources ...ArrayValueBinder) Field {
+	return newArrayField(dest, sources, uintSliceHandler(func(arrLength int) (func(uint64) error, func()) {
+		newArr := make([]uint16, 0, arrLength)
+		add := func(val uint64) error {
+			if err := checkUintBitsize(val, 16); err != nil {
+				return err
+			}
+			newArr = append(newArr, uint16(val)) // this is safe
+			return nil
+		}
+		save := func() { *dest = newArr }
+		return add, save
+	}))
+}
+
+func NewUint32SliceField(dest *[]uint32, sources ...ArrayValueBinder) Field {
+	return newArrayField(dest, sources, uintSliceHandler(func(arrLength int) (func(uint64) error, func()) {
+		newArr := make([]uint32, 0, arrLength)
+		add := func(val uint64) error {
+			if err := checkUintBitsize(val, 32); err != nil {
+				return err
+			}
+			newArr = append(newArr, uint32(val)) // this is safe
+			return nil
+		}
+		save := func() { *dest = newArr }
+		return add, save
+	}))
+}
+
+func NewUint64SliceField(dest *[]uint64, sources ...ArrayValueBinder) Field {
+	return newArrayField(dest, sources, uintSliceHandler(func(arrLength int) (func(uint64) error, func()) {
+		newArr := make([]uint64, 0, arrLength)
+		add := func(val uint64) error {
+			newArr = append(newArr, val)
+			return nil
+		}
+		save := func() { *dest = newArr }
+		return add, save
+	}))
+}

--- a/callbacks.go
+++ b/callbacks.go
@@ -1,0 +1,43 @@
+package croconf
+
+type callbackBinding struct {
+	apply func() error
+}
+
+func (cb *callbackBinding) Apply() error {
+	return cb.apply()
+}
+
+func NewCallbackBinding(callback func() error) Binding {
+	return &callbackBinding{apply: callback}
+}
+
+type callbackBindingFromSource struct {
+	*callbackBinding
+	source    Source
+	boundName string
+}
+
+func (cbs *callbackBindingFromSource) Source() Source {
+	return cbs.source
+}
+
+func (cbs *callbackBindingFromSource) BoundName() string {
+	return cbs.boundName
+}
+
+func NewCallbackBindingFromSource(source Source, boundName string, callback func() error) BindingFromSource {
+	return &callbackBindingFromSource{
+		callbackBinding: &callbackBinding{apply: callback},
+		source:          source,
+		boundName:       boundName,
+	}
+}
+
+func wrapBinding(origBinding Binding, newCallback func() error) Binding {
+	if fromSource, ok := origBinding.(BindingFromSource); ok {
+		return NewCallbackBindingFromSource(fromSource.Source(), fromSource.BoundName(), newCallback)
+	} else {
+		return NewCallbackBinding(newCallback)
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-var ErrorMissing = errors.New("field is missing in config source") // TODO: improve
+var ErrorMissing = errors.New("field is missing in config source") // TODO: remove?
 
 type BindFieldMissingError struct {
 	SourceName string

--- a/example/conf_global.go
+++ b/example/conf_global.go
@@ -21,8 +21,6 @@ func NewGlobalConfig(
 	envVarsSource *croconf.SourceEnvVars,
 ) (*GlobalConfig, error) {
 	cm := croconf.NewManager()
-	cm.AddSource(envVarsSource)
-	cm.AddSource(cliSource)
 	conf := &GlobalConfig{cm: cm}
 
 	cm.AddField(

--- a/example/conf_script.go
+++ b/example/conf_script.go
@@ -39,9 +39,6 @@ func NewScriptConfig(
 	jsonSource *croconf.SourceJSON,
 ) (*ScriptConfig, error) {
 	cm := croconf.NewManager()
-	cm.AddSource(jsonSource)
-	cm.AddSource(envVarsSource)
-	cm.AddSource(cliSource)
 	conf := &ScriptConfig{GlobalConfig: globalConf, cm: cm} // TODO: somehow save the sources in the struct as well?
 
 	cm.AddField(

--- a/example/conf_script.go
+++ b/example/conf_script.go
@@ -146,34 +146,27 @@ type scenariosField struct {
 	dest   *lib.ScenarioConfigs
 	source *croconf.SourceJSON
 	id     string
-	wasSet bool
 }
 
 func (sf *scenariosField) Destination() interface{} {
 	return sf.dest
 }
 
-func (sf *scenariosField) Consolidate() []error {
-	*sf.dest = lib.ScenarioConfigs{
-		lib.DefaultScenarioName: executor.NewPerVUIterationsConfig(lib.DefaultScenarioName),
-	}
+func (sf *scenariosField) Bindings() []croconf.Binding {
+	return []croconf.Binding{
+		croconf.NewCallbackBinding(func() error {
+			*sf.dest = lib.ScenarioConfigs{
+				lib.DefaultScenarioName: executor.NewPerVUIterationsConfig(lib.DefaultScenarioName),
+			}
+			return nil
+		}),
+		croconf.NewCallbackBindingFromSource(sf.source, sf.id, func() error {
+			jsonVal, ok := sf.source.Lookup(sf.id)
+			if !ok {
+				return nil
+			}
 
-	jsonVal, ok := sf.source.Lookup(sf.id)
-	if !ok {
-		return nil
+			return sf.dest.UnmarshalJSON(jsonVal)
+		}),
 	}
-
-	if err := sf.dest.UnmarshalJSON(jsonVal); err != nil {
-		return []error{err}
-	}
-	sf.wasSet = true
-
-	return nil
-}
-
-func (sf *scenariosField) ValueSource() croconf.Source {
-	if sf.wasSet {
-		return sf.source
-	}
-	return nil
 }

--- a/example/main.go
+++ b/example/main.go
@@ -41,7 +41,7 @@ func runCommand(
 ) {
 	jsonConfigContents, err := ioutil.ReadFile(globalConf.JSONConfigPath)
 	if err != nil {
-		if globalConf.cm.Field(&globalConf.JSONConfigPath).ValueSource() != nil {
+		if globalConf.cm.Field(&globalConf.JSONConfigPath).HasBeenSetFromSource() {
 			// If this was explicitly set, treat any failure to open it as a fatal error
 			log.Fatal(err)
 		}
@@ -83,14 +83,15 @@ func dumpField(cm *croconf.Manager, field interface{}, fieldName string) {
 	}
 
 	fieldMeta := cm.Field(field)
-	if source := fieldMeta.ValueSource(); source != nil {
+	if fieldMeta.HasBeenSetFromSource() {
+		binding := fieldMeta.LastBindingFromSource()
 		fmt.Printf(
-			"Field %s was manually set by source '%s' with value '%s'\n",
-			fieldName, source.GetName(), jsonResult,
+			"Field %s was manually set by source '%s' (field %s) with value '%s'\n",
+			fieldName, binding.Source().GetName(), binding.BoundName(), jsonResult,
 		)
 	} else {
 		fmt.Printf(
-			"Field %s was using the default value of '%s'\n",
+			"Field %s was using the default/non-source value of '%s'\n",
 			fieldName, jsonResult,
 		)
 	}

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -30,6 +30,8 @@ func (p *Parser) RegisterSlice(long, short string) {
 	}
 }
 
+// TODO: split apart and remove nolint
+//nolint: funlen,gocognit
 func (p *Parser) Parse(tt []string) (*Set, error) {
 	// TODO: refactor to remove this
 	args := make([]string, len(tt))

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -133,7 +133,6 @@ func (p *Parser) Parse(tt []string) (*Set, error) {
 		default:
 			fs.posArgs = append(fs.posArgs, arg)
 		}
-
 	}
 	return &fs, err
 }

--- a/flag/flag_test.go
+++ b/flag/flag_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestSet_Option(t *testing.T) {
+	t.Parallel()
 	fs := Set{
 		flags: map[string]string{
 			"foo": "bar",
@@ -18,6 +19,7 @@ func TestSet_Option(t *testing.T) {
 }
 
 func TestSet_Positional(t *testing.T) {
+	t.Parallel()
 	fs := Set{
 		posArgs: []string{"run", "foo"},
 	}
@@ -33,7 +35,9 @@ func TestSet_Positional(t *testing.T) {
 }
 
 func TestParse(t *testing.T) {
+	t.Parallel()
 	t.Run("LongOption", func(t *testing.T) {
+		t.Parallel()
 		//{in: "--test=false", exp: []string{}},
 		//{in: "--test false", exp: []string{}},
 
@@ -57,6 +61,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("LongOptionWithSpace", func(t *testing.T) {
+		t.Parallel()
 		args := []string{"run", "--user", "u1", "--", "hello.go"}
 
 		p := NewParser()
@@ -77,6 +82,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("LongOptionWithUnary", func(t *testing.T) {
+		t.Parallel()
 		args := []string{"--bool", "foo"}
 
 		p := NewParser()
@@ -100,6 +106,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("LongOptionSlice", func(t *testing.T) {
+		t.Parallel()
 		args := []string{"--nums", "0", "alpha", "--nums=42"}
 
 		p := NewParser()
@@ -121,6 +128,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("ShortOption", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			in  []string
 			exp map[string]string
@@ -165,7 +173,6 @@ func TestParse(t *testing.T) {
 			if !reflect.DeepEqual(fs.flags, tt.exp) {
 				t.Errorf("unexpected flag %v %+v", tt.in, fs.flags)
 			}
-
 		}
 	})
 }

--- a/managed_field.go
+++ b/managed_field.go
@@ -1,9 +1,14 @@
 package croconf
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type ManagedField struct {
 	Field
+
+	lastBindingFromSource BindingFromSource // nil for default value
 
 	Name        string
 	Description string
@@ -13,8 +18,47 @@ type ManagedField struct {
 	// information and examples, annotations, etc.
 }
 
+func (mf *ManagedField) ApplyDefault() error {
+	for _, binding := range mf.Field.Bindings() {
+		if fromSource, ok := binding.(BindingFromSource); ok {
+			// nil source means the default value
+			if fromSource.Source() == nil {
+				return fromSource.Apply()
+			}
+		}
+	}
+	return nil
+}
+
+func (mf *ManagedField) Consolidate() []error {
+	// TODO: verify that sources have been initialized
+	var errs []error
+	for _, binding := range mf.Field.Bindings() {
+		err := binding.Apply()
+		if err == nil {
+			if fromSource, ok := binding.(BindingFromSource); ok {
+				mf.lastBindingFromSource = fromSource
+			}
+			continue
+		}
+		var bindErr *BindFieldMissingError
+		if !errors.Is(ErrorMissing, err) && !errors.As(err, &bindErr) {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+func (mf *ManagedField) LastBindingFromSource() BindingFromSource {
+	return mf.lastBindingFromSource
+}
+
+func (mf *ManagedField) HasBeenSetFromSource() bool {
+	return mf.lastBindingFromSource != nil && mf.lastBindingFromSource.Source() != nil
+}
+
 func (mf *ManagedField) Validate() error {
-	if mf.Required && mf.Field.ValueSource() == nil {
+	if mf.Required && !mf.HasBeenSetFromSource() {
 		return fmt.Errorf("Field %s is required, but no value was set", mf.Name)
 	}
 

--- a/source_cli_flags.go
+++ b/source_cli_flags.go
@@ -61,8 +61,24 @@ type cliBinding struct {
 	lookupfn func() (string, error)
 }
 
-func (cb *cliBinding) GetSource() Source {
+var _ interface {
+	BindingFromSource
+	BindingWithName
+} = &cliBinding{}
+
+func (cb *cliBinding) Source() Source {
 	return cb.source
+}
+
+func (cb *cliBinding) BoundName() string {
+	// TODO: improve?
+	if cb.position > 0 {
+		return fmt.Sprintf("argument #%d", cb.position)
+	}
+	if cb.shorthand != "" {
+		return fmt.Sprintf("--%s / -%s", cb.shorthand, cb.longhand)
+	}
+	return fmt.Sprintf("--%s", cb.longhand)
 }
 
 // TODO: refactor
@@ -115,8 +131,7 @@ func (cb *cliBinding) BindIntValueTo(dest *int64) func() error {
 	return func() error {
 		v, err := cb.lookup()
 		if err != nil {
-			// TODO what to use? cb.shorthand or cb.longhand or pos or smth joint
-			return NewBindFieldMissingError(cb.source.GetName(), cb.longhand)
+			return NewBindFieldMissingError(cb.source.GetName(), cb.BoundName())
 		}
 		val, bindErr := parseInt(v)
 		if bindErr != nil {
@@ -131,8 +146,7 @@ func (cb *cliBinding) BindUintValueTo(dest *uint64) func() error {
 	return func() error {
 		v, err := cb.lookup()
 		if err != nil {
-			// TODO what to use? cb.shorthand or cb.longhand or pos or smth joint
-			return NewBindFieldMissingError(cb.source.GetName(), cb.longhand)
+			return NewBindFieldMissingError(cb.source.GetName(), cb.BoundName())
 		}
 		val, bindErr := parseUint(v)
 		if bindErr != nil {
@@ -147,8 +161,7 @@ func (cb *cliBinding) BindFloatValueTo(dest *float64) func() error {
 	return func() error {
 		v, err := cb.lookup()
 		if err != nil {
-			// TODO what to use? cb.shorthand or cb.longhand or pos or smth joint
-			return NewBindFieldMissingError(cb.source.GetName(), cb.longhand)
+			return NewBindFieldMissingError(cb.source.GetName(), cb.BoundName())
 		}
 		val, bindErr := parseFloat(v)
 		if bindErr != nil {

--- a/source_cli_flags.go
+++ b/source_cli_flags.go
@@ -47,7 +47,7 @@ func (sc *SourceCLI) FromNameAndShorthand(name, shorthand string) *cliBinding {
 	}
 }
 
-func (sc *SourceCLI) FromPositionalArg(position int) LazySingleValueBinding {
+func (sc *SourceCLI) FromPositionalArg(position int) LazySingleValueBinder {
 	return &cliBinding{source: sc, position: position}
 }
 
@@ -204,7 +204,7 @@ func (cab cliArrayBinding) Len() int {
 	return len(cab.arr)
 }
 
-func (cab cliArrayBinding) Element(i int) LazySingleValueBinding {
+func (cab cliArrayBinding) Element(i int) LazySingleValueBinder {
 	cbcopy := *cab.cb
 	cbcopy.lookupfn = func() (string, error) {
 		if i >= len(cab.arr) {

--- a/source_cli_flags.go
+++ b/source_cli_flags.go
@@ -111,48 +111,51 @@ func (cb *cliBinding) BindTextBasedValueTo(dest encoding.TextUnmarshaler) func()
 	})
 }
 
-func (cb *cliBinding) BindIntValue() func(int) (int64, error) {
-	return func(bitSize int) (int64, error) {
+func (cb *cliBinding) BindIntValueTo(dest *int64) func() error {
+	return func() error {
 		v, err := cb.lookup()
 		if err != nil {
 			// TODO what to use? cb.shorthand or cb.longhand or pos or smth joint
-			return 0, NewBindFieldMissingError(cb.source.GetName(), cb.longhand)
+			return NewBindFieldMissingError(cb.source.GetName(), cb.longhand)
 		}
-		val, bindErr := parseInt(v, 10, bitSize)
+		val, bindErr := parseInt(v)
 		if bindErr != nil {
-			return 0, bindErr.withFuncName("BindIntValue")
+			return bindErr.withFuncName("BindIntValue")
 		}
-		return val, nil
+		*dest = val
+		return nil
 	}
 }
 
-func (cb *cliBinding) BindUintValue() func(bitSize int) (uint64, error) {
-	return func(bitSize int) (uint64, error) {
+func (cb *cliBinding) BindUintValueTo(dest *uint64) func() error {
+	return func() error {
 		v, err := cb.lookup()
 		if err != nil {
 			// TODO what to use? cb.shorthand or cb.longhand or pos or smth joint
-			return 0, NewBindFieldMissingError(cb.source.GetName(), cb.longhand)
+			return NewBindFieldMissingError(cb.source.GetName(), cb.longhand)
 		}
-		val, bindErr := parseUint(v, 10, bitSize)
+		val, bindErr := parseUint(v)
 		if bindErr != nil {
-			return 0, bindErr.withFuncName("BindIntValue")
+			return bindErr.withFuncName("BindIntValue")
 		}
-		return val, nil
+		*dest = val
+		return nil
 	}
 }
 
-func (cb *cliBinding) BindFloatValue() func(bitSize int) (float64, error) {
-	return func(bitSize int) (float64, error) {
+func (cb *cliBinding) BindFloatValueTo(dest *float64) func() error {
+	return func() error {
 		v, err := cb.lookup()
 		if err != nil {
 			// TODO what to use? cb.shorthand or cb.longhand or pos or smth joint
-			return 0, NewBindFieldMissingError(cb.source.GetName(), cb.longhand)
+			return NewBindFieldMissingError(cb.source.GetName(), cb.longhand)
 		}
-		val, bindErr := parseFloat(v, bitSize)
+		val, bindErr := parseFloat(v)
 		if bindErr != nil {
-			return 0, bindErr.withFuncName("BindIntValue")
+			return bindErr.withFuncName("BindIntValue")
 		}
-		return val, nil
+		*dest = val
+		return nil
 	}
 }
 

--- a/source_cli_flags_test.go
+++ b/source_cli_flags_test.go
@@ -35,8 +35,8 @@ func TestCLIBinding_BindStringValueTo(t *testing.T) {
 			return
 		}
 
-		bindfn := field.BindBoolValueTo(&b)
-		err = bindfn()
+		binding := field.BindBoolValueTo(&b)
+		err = binding.Apply()
 		if err != nil {
 			t.Errorf("test: %s: got unexpected error: %v", name, err)
 			return

--- a/source_cli_flags_test.go
+++ b/source_cli_flags_test.go
@@ -3,6 +3,7 @@ package croconf
 import "testing"
 
 func TestCLIBinding_BindStringValueTo(t *testing.T) {
+	t.Parallel()
 	tests := map[string]struct {
 		args []string
 	}{

--- a/source_defaults.go
+++ b/source_defaults.go
@@ -2,7 +2,6 @@ package croconf
 
 import (
 	"encoding"
-	"fmt"
 )
 
 // TODO: make more flexible with callbacks, so that besides defaut values, we
@@ -36,15 +35,10 @@ func DefaultStringValue(s string) interface {
 
 type defaultIntValue int64
 
-func (div defaultIntValue) BindIntValue() func(bitSize int) (int64, error) {
-	return func(bitSize int) (int64, error) {
-		val := int64(div)
-		// See https://golang.org/pkg/math/#pkg-constants
-		min, max := int64(-1<<(bitSize-1)), int64(1<<(bitSize-1)-1)
-		if val < min || val > max {
-			return 0, fmt.Errorf("invalid value %d, has to be between %d and %d", val, min, max)
-		}
-		return val, nil
+func (div defaultIntValue) BindIntValueTo(dest *int64) func() error {
+	return func() error {
+		*dest = int64(div)
+		return nil
 	}
 }
 

--- a/source_defaults.go
+++ b/source_defaults.go
@@ -22,13 +22,14 @@ func (dsv defaultStringValue) BindTextBasedValueTo(dest encoding.TextUnmarshaler
 	}
 }
 
-func (dsv defaultStringValue) GetSource() Source {
+func (dsv defaultStringValue) Source() Source {
 	return nil
 }
 
 func DefaultStringValue(s string) interface {
 	StringValueBinding
 	TextBasedValueBinding
+	BindingFromSource
 } {
 	return defaultStringValue(s)
 }
@@ -42,17 +43,25 @@ func (div defaultIntValue) BindIntValueTo(dest *int64) func() error {
 	}
 }
 
-func (div defaultIntValue) GetSource() Source {
+func (div defaultIntValue) Source() Source {
 	return nil
 }
 
-func DefaultIntValue(i int64) IntValueBinding {
+func DefaultIntValue(i int64) interface {
+	IntValueBinding
+	BindingFromSource
+} {
 	return defaultIntValue(i)
 }
 
 type DefaultCustomValue func()
 
-func (dcv DefaultCustomValue) GetSource() Source {
+var _ interface {
+	CustomValueBinding
+	BindingFromSource
+} = DefaultCustomValue(nil)
+
+func (dcv DefaultCustomValue) Source() Source {
 	return nil
 }
 

--- a/source_defaults.go
+++ b/source_defaults.go
@@ -27,8 +27,8 @@ func (dsv defaultStringValue) Source() Source {
 }
 
 func DefaultStringValue(s string) interface {
-	StringValueBinding
-	TextBasedValueBinding
+	StringValueBinder
+	TextBasedValueBinder
 	BindingFromSource
 } {
 	return defaultStringValue(s)
@@ -48,7 +48,7 @@ func (div defaultIntValue) Source() Source {
 }
 
 func DefaultIntValue(i int64) interface {
-	IntValueBinding
+	IntValueBinder
 	BindingFromSource
 } {
 	return defaultIntValue(i)
@@ -57,7 +57,7 @@ func DefaultIntValue(i int64) interface {
 type DefaultCustomValue func()
 
 var _ interface {
-	CustomValueBinding
+	CustomValueBinder
 	BindingFromSource
 } = DefaultCustomValue(nil)
 

--- a/source_defaults.go
+++ b/source_defaults.go
@@ -4,43 +4,41 @@ import (
 	"encoding"
 )
 
-// TODO: make more flexible with callbacks, so that besides defaut values, we
-// can use these for custom wrappers as well?
+const defaultsBoundName = "default"
+
+// TODO: setting Source=nil for defaults is confusing, should we just not set
+// any Source at all for them? By convention, if the first binding doesn't have
+// a source, we can consider it the default one?
 
 type defaultStringValue string
 
-func (dsv defaultStringValue) BindStringValueTo(dest *string) func() error {
-	return func() error {
+func (dsv defaultStringValue) BindStringValueTo(dest *string) Binding {
+	return NewCallbackBindingFromSource(nil, defaultsBoundName, func() error {
 		*dest = string(dsv)
 		return nil
-	}
+	})
 }
 
-func (dsv defaultStringValue) BindTextBasedValueTo(dest encoding.TextUnmarshaler) func() error {
-	return func() error {
+func (dsv defaultStringValue) BindTextBasedValueTo(dest encoding.TextUnmarshaler) Binding {
+	return NewCallbackBindingFromSource(nil, defaultsBoundName, func() error {
 		return dest.UnmarshalText([]byte(dsv))
-	}
-}
-
-func (dsv defaultStringValue) Source() Source {
-	return nil
+	})
 }
 
 func DefaultStringValue(s string) interface {
 	StringValueBinder
 	TextBasedValueBinder
-	BindingFromSource
 } {
 	return defaultStringValue(s)
 }
 
 type defaultIntValue int64
 
-func (div defaultIntValue) BindIntValueTo(dest *int64) func() error {
-	return func() error {
+func (div defaultIntValue) BindIntValueTo(dest *int64) Binding {
+	return NewCallbackBindingFromSource(nil, defaultsBoundName, func() error {
 		*dest = int64(div)
 		return nil
-	}
+	})
 }
 
 func (div defaultIntValue) Source() Source {
@@ -49,7 +47,6 @@ func (div defaultIntValue) Source() Source {
 
 func DefaultIntValue(i int64) interface {
 	IntValueBinder
-	BindingFromSource
 } {
 	return defaultIntValue(i)
 }
@@ -58,18 +55,17 @@ type DefaultCustomValue func()
 
 var _ interface {
 	CustomValueBinder
-	BindingFromSource
 } = DefaultCustomValue(nil)
 
 func (dcv DefaultCustomValue) Source() Source {
 	return nil
 }
 
-func (dcv DefaultCustomValue) BindValue() func() error {
-	return func() error {
+func (dcv DefaultCustomValue) BindValue() Binding {
+	return NewCallbackBindingFromSource(nil, defaultsBoundName, func() error {
 		dcv()
 		return nil
-	}
+	})
 }
 
 // TODO: sources for the rest of the types

--- a/source_env_vars.go
+++ b/source_env_vars.go
@@ -49,8 +49,17 @@ type envBinding struct {
 	lookup func() (string, error)
 }
 
-func (eb *envBinding) GetSource() Source {
+var _ interface {
+	BindingFromSource
+	BindingWithName
+} = &envBinding{}
+
+func (eb *envBinding) Source() Source {
 	return eb.source
+}
+
+func (eb *envBinding) BoundName() string {
+	return eb.name
 }
 
 func (eb *envBinding) BindStringValueTo(dest *string) func() error {

--- a/source_env_vars.go
+++ b/source_env_vars.go
@@ -29,8 +29,8 @@ func (sev *SourceEnvVars) GetName() string {
 	return "environment variables" // TODO
 }
 
-func (sev *SourceEnvVars) From(name string) *envBinding {
-	return &envBinding{
+func (sev *SourceEnvVars) From(name string) *envBinder {
+	return &envBinder{
 		source: sev,
 		name:   name,
 		lookup: func() (string, error) {
@@ -43,38 +43,32 @@ func (sev *SourceEnvVars) From(name string) *envBinding {
 	}
 }
 
-type envBinding struct {
+type envBinder struct {
 	source Source
 	name   string
 	lookup func() (string, error)
 }
 
-var _ interface {
-	BindingFromSource
-	BindingWithName
-} = &envBinding{}
-
-func (eb *envBinding) Source() Source {
-	return eb.source
+func (eb *envBinder) newBinding(apply func() error) *envBinding {
+	return &envBinding{
+		binder: eb,
+		apply:  apply,
+	}
 }
 
-func (eb *envBinding) BoundName() string {
-	return eb.name
-}
-
-func (eb *envBinding) BindStringValueTo(dest *string) func() error {
-	return func() error {
+func (eb *envBinder) BindStringValueTo(dest *string) Binding {
+	return eb.newBinding(func() error {
 		val, err := eb.lookup()
 		if err != nil {
 			return err
 		}
 		*dest = val
 		return nil
-	}
+	})
 }
 
-func (eb *envBinding) BindIntValueTo(dest *int64) func() error {
-	return func() error {
+func (eb *envBinder) BindIntValueTo(dest *int64) Binding {
+	return eb.newBinding(func() error {
 		val, err := eb.lookup()
 		if err != nil {
 			// TODO: we might want to integrate custom error into lookup() method
@@ -86,11 +80,11 @@ func (eb *envBinding) BindIntValueTo(dest *int64) func() error {
 		}
 		*dest = intVal
 		return nil
-	}
+	})
 }
 
-func (eb *envBinding) BindUintValueTo(dest *uint64) func() error {
-	return func() error {
+func (eb *envBinder) BindUintValueTo(dest *uint64) Binding {
+	return eb.newBinding(func() error {
 		val, err := eb.lookup()
 		if err != nil {
 			// TODO: we might want to integrate custom error into lookup() method
@@ -102,11 +96,11 @@ func (eb *envBinding) BindUintValueTo(dest *uint64) func() error {
 		}
 		*dest = uintVal
 		return nil
-	}
+	})
 }
 
-func (eb *envBinding) BindFloatValueTo(dest *float64) func() error {
-	return func() error {
+func (eb *envBinder) BindFloatValueTo(dest *float64) Binding {
+	return eb.newBinding(func() error {
 		strVal, err := eb.lookup()
 		if err != nil {
 			// TODO: we might want to integrate custom error into lookup() method
@@ -118,11 +112,11 @@ func (eb *envBinding) BindFloatValueTo(dest *float64) func() error {
 		}
 		*dest = val
 		return nil
-	}
+	})
 }
 
-func (eb *envBinding) BindBoolValueTo(dest *bool) func() error {
-	return func() error {
+func (eb *envBinder) BindBoolValueTo(dest *bool) Binding {
+	return eb.newBinding(func() error {
 		val, err := eb.lookup()
 		if err != nil {
 			return err
@@ -133,54 +127,45 @@ func (eb *envBinding) BindBoolValueTo(dest *bool) func() error {
 		}
 		*dest = b
 		return nil
-	}
+	})
 }
 
-func (eb *envBinding) BindTextBasedValueTo(dest encoding.TextUnmarshaler) func() error {
-	return func() error {
+func (eb *envBinder) BindTextBasedValueTo(dest encoding.TextUnmarshaler) Binding {
+	return eb.newBinding(func() error {
 		val, err := eb.lookup()
 		if err != nil {
 			return NewBindFieldMissingError(eb.source.GetName(), eb.name)
 		}
 
 		return dest.UnmarshalText([]byte(val))
-	}
+	})
 }
 
-func (eb *envBinding) BindArray() func() (Array, error) {
-	return func() (Array, error) {
+func (eb *envBinder) BindArrayValueTo(length *int, element *func(int) LazySingleValueBinder) Binding {
+	return eb.newBinding(func() error {
 		val, err := eb.lookup()
 		if err != nil {
-			return nil, NewBindFieldMissingError(eb.source.GetName(), eb.name)
+			return NewBindFieldMissingError(eb.source.GetName(), eb.name)
 		}
 
 		arr := strings.Split(val, ",") // TODO: figure out how to make the delimiter configurable
 
-		return &envVarArray{eb: eb, array: arr}, nil
-	}
-}
-
-type envVarArray struct {
-	eb    *envBinding
-	array []string
-}
-
-func (eva *envVarArray) Len() int {
-	return len(eva.array)
-}
-
-func (eva *envVarArray) Element(elNum int) LazySingleValueBinder {
-	name := fmt.Sprintf("%s[%d]", eva.eb.name, elNum)
-	return &envBinding{
-		source: eva.eb.source,
-		name:   name,
-		lookup: func() (string, error) {
-			if elNum >= len(eva.array) {
-				return "", fmt.Errorf("tried to access invalid element %s, array only has %d elements", name, elNum)
+		*length = len(arr)
+		*element = func(elNum int) LazySingleValueBinder {
+			name := fmt.Sprintf("%s[%d]", eb.name, elNum)
+			return &envBinder{
+				source: eb.source,
+				name:   name,
+				lookup: func() (string, error) {
+					if elNum >= len(arr) {
+						return "", fmt.Errorf("tried to access invalid element %s, array only has %d elements", name, elNum)
+					}
+					return arr[elNum], nil
+				},
 			}
-			return eva.array[elNum], nil
-		},
-	}
+		}
+		return nil
+	})
 }
 
 func parseEnvKeyValue(kv string) (string, string) {
@@ -188,4 +173,26 @@ func parseEnvKeyValue(kv string) (string, string) {
 		return kv[:idx], kv[idx+1:]
 	}
 	return kv, ""
+}
+
+type envBinding struct {
+	binder *envBinder
+	apply  func() error
+}
+
+var _ interface {
+	Binding
+	BindingFromSource
+} = &envBinding{}
+
+func (eb *envBinding) Apply() error {
+	return eb.apply()
+}
+
+func (eb *envBinding) Source() Source {
+	return eb.binder.source
+}
+
+func (eb *envBinding) BoundName() string {
+	return eb.binder.name
 }

--- a/source_env_vars.go
+++ b/source_env_vars.go
@@ -169,7 +169,7 @@ func (eva *envVarArray) Len() int {
 	return len(eva.array)
 }
 
-func (eva *envVarArray) Element(elNum int) LazySingleValueBinding {
+func (eva *envVarArray) Element(elNum int) LazySingleValueBinder {
 	name := fmt.Sprintf("%s[%d]", eva.eb.name, elNum)
 	return &envBinding{
 		source: eva.eb.source,

--- a/source_env_vars.go
+++ b/source_env_vars.go
@@ -64,48 +64,51 @@ func (eb *envBinding) BindStringValueTo(dest *string) func() error {
 	}
 }
 
-func (eb *envBinding) BindIntValue() func(bitSize int) (int64, error) {
-	return func(bitSize int) (int64, error) {
+func (eb *envBinding) BindIntValueTo(dest *int64) func() error {
+	return func() error {
 		val, err := eb.lookup()
 		if err != nil {
 			// TODO: we might want to integrate custom error into lookup() method
-			return 0, NewBindFieldMissingError(eb.source.GetName(), eb.name)
+			return NewBindFieldMissingError(eb.source.GetName(), eb.name)
 		}
-		intVal, bindErr := parseInt(val, 10, bitSize)
+		intVal, bindErr := parseInt(val)
 		if bindErr != nil {
-			return 0, bindErr.withFuncName("BindIntValue")
+			return bindErr.withFuncName("BindIntValue")
 		}
-		return intVal, nil
+		*dest = intVal
+		return nil
 	}
 }
 
-func (eb *envBinding) BindUintValue() func(bitSize int) (uint64, error) {
-	return func(bitSize int) (uint64, error) {
+func (eb *envBinding) BindUintValueTo(dest *uint64) func() error {
+	return func() error {
 		val, err := eb.lookup()
 		if err != nil {
 			// TODO: we might want to integrate custom error into lookup() method
-			return 0, NewBindFieldMissingError(eb.source.GetName(), eb.name)
+			return NewBindFieldMissingError(eb.source.GetName(), eb.name)
 		}
-		intVal, bindErr := parseUint(val, 10, bitSize)
+		uintVal, bindErr := parseUint(val)
 		if bindErr != nil {
-			return 0, bindErr.withFuncName("BindUintValue")
+			return bindErr.withFuncName("BindUintValue")
 		}
-		return intVal, nil
+		*dest = uintVal
+		return nil
 	}
 }
 
-func (eb *envBinding) BindFloatValue() func(bitSize int) (float64, error) {
-	return func(bitSize int) (float64, error) {
+func (eb *envBinding) BindFloatValueTo(dest *float64) func() error {
+	return func() error {
 		strVal, err := eb.lookup()
 		if err != nil {
 			// TODO: we might want to integrate custom error into lookup() method
-			return 0, NewBindFieldMissingError(eb.source.GetName(), eb.name)
+			return NewBindFieldMissingError(eb.source.GetName(), eb.name)
 		}
-		val, bindErr := parseFloat(strVal, bitSize)
+		val, bindErr := parseFloat(strVal)
 		if bindErr != nil {
-			return 0, bindErr.withFuncName("BindFloatValue")
+			return bindErr.withFuncName("BindFloatValue")
 		}
-		return val, nil
+		*dest = val
+		return nil
 	}
 }
 

--- a/source_env_vars_test.go
+++ b/source_env_vars_test.go
@@ -19,7 +19,8 @@ func TestEnvVarsBindIntValue(t *testing.T) {
 	}
 
 	var val int64
-	err := vus.BindIntValueTo(&val)()
+	valBinding := vus.BindIntValueTo(&val)
+	err := valBinding.Apply()
 	if err != nil {
 		t.Errorf("BindIntValueTo error: %s", err)
 	}
@@ -27,7 +28,8 @@ func TestEnvVarsBindIntValue(t *testing.T) {
 		t.Errorf("BindIntValue: got %d, expected %d", val, expected)
 	}
 
-	err = missed.BindIntValueTo(&val)()
+	valBinding = missed.BindIntValueTo(&val)
+	err = valBinding.Apply()
 	if err == nil {
 		t.Error("BindIntValue: expected field missing error")
 	}
@@ -35,7 +37,8 @@ func TestEnvVarsBindIntValue(t *testing.T) {
 		t.Error("BindIntValue: unexpected error message:", err)
 	}
 
-	err = k6UserAgent.BindIntValueTo(&val)()
+	valBinding = k6UserAgent.BindIntValueTo(&val)
+	err = valBinding.Apply()
 	if err == nil {
 		t.Error("BindIntValue: expected syntax error")
 	}
@@ -58,7 +61,8 @@ func TestEnvVarsBindUintValue(t *testing.T) {
 	}
 
 	var val uint64
-	err := vus.BindUintValueTo(&val)()
+	valBinding := vus.BindUintValueTo(&val)
+	err := valBinding.Apply()
 	if err != nil {
 		t.Errorf("BindUintValueTo error: %s", err)
 	}
@@ -66,7 +70,8 @@ func TestEnvVarsBindUintValue(t *testing.T) {
 		t.Errorf("BindUintValue: got %d, expected %d", val, expected)
 	}
 
-	err = missed.BindUintValueTo(&val)()
+	valBinding = missed.BindUintValueTo(&val)
+	err = valBinding.Apply()
 	if err == nil {
 		t.Error("BindUintValue: expected field missing error")
 	}
@@ -74,7 +79,8 @@ func TestEnvVarsBindUintValue(t *testing.T) {
 		t.Error("BindUintValue: unexpected error message:", err)
 	}
 
-	err = k6UserAgent.BindUintValueTo(&val)()
+	valBinding = k6UserAgent.BindUintValueTo(&val)
+	err = valBinding.Apply()
 	if err == nil {
 		t.Error("BindUintValue: expected syntax error")
 	}
@@ -98,7 +104,8 @@ func TestEnvVarsFloatValue(t *testing.T) {
 	}
 
 	var val float64
-	err := vus.BindFloatValueTo(&val)()
+	valBinding := vus.BindFloatValueTo(&val)
+	err := valBinding.Apply()
 	expected := float64(6)
 	if err != nil {
 		t.Errorf("BindFloatValue error: %s", err)
@@ -107,7 +114,8 @@ func TestEnvVarsFloatValue(t *testing.T) {
 		t.Errorf("BindFloatValue: got %f, expected %f", val, expected)
 	}
 
-	err = pi.BindFloatValueTo(&val)()
+	valBinding = pi.BindFloatValueTo(&val)
+	err = valBinding.Apply()
 	expected = float64(3.14)
 	if err != nil {
 		t.Errorf("BindFloatValue error: %s", err)
@@ -116,7 +124,8 @@ func TestEnvVarsFloatValue(t *testing.T) {
 		t.Errorf("BindFloatValue: got %f, expected %f", val, expected)
 	}
 
-	err = missed.BindFloatValueTo(&val)()
+	valBinding = missed.BindFloatValueTo(&val)
+	err = valBinding.Apply()
 	if err == nil {
 		t.Error("BindFloatValue: expected field missing error")
 	}
@@ -124,7 +133,8 @@ func TestEnvVarsFloatValue(t *testing.T) {
 		t.Error("BindFloatValue: unexpected error message:", err)
 	}
 
-	err = k6UserAgent.BindFloatValueTo(&val)()
+	valBinding = k6UserAgent.BindFloatValueTo(&val)
+	err = valBinding.Apply()
 	if err == nil {
 		t.Error("BindFloatValue: expected syntax error")
 	}

--- a/source_env_vars_test.go
+++ b/source_env_vars_test.go
@@ -1,137 +1,134 @@
 package croconf
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestEnvVarsBindIntValue(t *testing.T) {
+	t.Parallel()
 	environ := []string{"K6_VUS=6", "PI=3.14", "K6_CONFIG=./config.json", "K6_USER_AGENT=foo"}
 
-	vus := NewSourceFromEnv(environ).From("K6_VUS")
-	k6UserAgent := NewSourceFromEnv(environ).From("K6_USER_AGENT")
-	missed := NewSourceFromEnv(environ).From("MISSED")
+	source := NewSourceFromEnv(environ)
+	vus := source.From("K6_VUS")
+	k6UserAgent := source.From("K6_USER_AGENT")
+	missed := source.From("MISSED")
 
-	withFixedBytesSizeFunc := func(bytesSize int) {
-		val, err := vus.BindIntValue()(bytesSize)
-		expected := int64(6)
-		if err != nil {
-			t.Errorf("BindIntValueTo error: %s", err)
-		}
-		if val != expected {
-			t.Errorf("BindIntValue: got %d, expected %d", val, expected)
-		}
-
-		_, err = missed.BindIntValue()(bytesSize)
-		if err == nil {
-			t.Error("BindIntValue: expected field missing error")
-		}
-		if err.Error() != "field MISSED is missing in config source environment variables" {
-			t.Error("BindIntValue: unexpected error message:", err)
-		}
-
-		_, err = k6UserAgent.BindIntValue()(bytesSize)
-		if err == nil {
-			t.Error("BindIntValue: expected syntax error")
-		}
-		if err.Error() != "BindIntValue: parsing \"foo\": invalid syntax" {
-			t.Errorf("BindIntValue: unexpected error message")
-		}
+	if err := source.Initialize(); err != nil {
+		t.Fatalf("received an unexpected init error %s", err)
 	}
 
-	intBytesSizes := []int{0, 8, 16, 32, 64}
+	var val int64
+	err := vus.BindIntValueTo(&val)()
+	if err != nil {
+		t.Errorf("BindIntValueTo error: %s", err)
+	}
+	if expected := int64(6); val != expected {
+		t.Errorf("BindIntValue: got %d, expected %d", val, expected)
+	}
 
-	for _, byteSize := range intBytesSizes {
-		withFixedBytesSizeFunc(byteSize)
+	err = missed.BindIntValueTo(&val)()
+	if err == nil {
+		t.Error("BindIntValue: expected field missing error")
+	}
+	if err.Error() != "field MISSED is missing in config source environment variables" {
+		t.Error("BindIntValue: unexpected error message:", err)
+	}
+
+	err = k6UserAgent.BindIntValueTo(&val)()
+	if err == nil {
+		t.Error("BindIntValue: expected syntax error")
+	}
+	if err.Error() != "BindIntValue: parsing \"foo\": invalid syntax" {
+		t.Errorf("BindIntValue: unexpected error message")
 	}
 }
 
 func TestEnvVarsBindUintValue(t *testing.T) {
+	t.Parallel()
 	environ := []string{"K6_VUS=6", "PI=3.14", "K6_CONFIG=./config.json", "K6_USER_AGENT=foo"}
 
-	vus := NewSourceFromEnv(environ).From("K6_VUS")
-	k6UserAgent := NewSourceFromEnv(environ).From("K6_USER_AGENT")
-	missed := NewSourceFromEnv(environ).From("MISSED")
+	source := NewSourceFromEnv(environ)
+	vus := source.From("K6_VUS")
+	k6UserAgent := source.From("K6_USER_AGENT")
+	missed := source.From("MISSED")
 
-	withFixedBytesSizeFunc := func(bytesSize int) {
-		val, err := vus.BindUintValue()(bytesSize)
-		expected := uint64(6)
-		if err != nil {
-			t.Errorf("BindUintValueTo error: %s", err)
-		}
-		if val != expected {
-			t.Errorf("BindUintValue: got %d, expected %d", val, expected)
-		}
-
-		_, err = missed.BindUintValue()(bytesSize)
-		if err == nil {
-			t.Error("BindUintValue: expected field missing error")
-		}
-		if err.Error() != "field MISSED is missing in config source environment variables" {
-			t.Error("BindUintValue: unexpected error message:", err)
-		}
-
-		_, err = k6UserAgent.BindUintValue()(bytesSize)
-		if err == nil {
-			t.Error("BindUintValue: expected syntax error")
-		}
-		if err.Error() != "BindUintValue: parsing \"foo\": invalid syntax" {
-			t.Errorf("BindUintValue: unexpected error message")
-		}
+	if err := source.Initialize(); err != nil {
+		t.Fatalf("received an unexpected init error %s", err)
 	}
 
-	intBytesSizes := []int{0, 8, 16, 32, 64}
+	var val uint64
+	err := vus.BindUintValueTo(&val)()
+	if err != nil {
+		t.Errorf("BindUintValueTo error: %s", err)
+	}
+	if expected := uint64(6); val != expected {
+		t.Errorf("BindUintValue: got %d, expected %d", val, expected)
+	}
 
-	for _, byteSize := range intBytesSizes {
-		withFixedBytesSizeFunc(byteSize)
+	err = missed.BindUintValueTo(&val)()
+	if err == nil {
+		t.Error("BindUintValue: expected field missing error")
+	}
+	if err.Error() != "field MISSED is missing in config source environment variables" {
+		t.Error("BindUintValue: unexpected error message:", err)
+	}
+
+	err = k6UserAgent.BindUintValueTo(&val)()
+	if err == nil {
+		t.Error("BindUintValue: expected syntax error")
+	}
+	if err.Error() != "BindUintValue: parsing \"foo\": invalid syntax" {
+		t.Errorf("BindUintValue: unexpected error message")
 	}
 }
 
 func TestEnvVarsFloatValue(t *testing.T) {
+	t.Parallel()
 	environ := []string{"K6_VUS=6", "PI=3.14", "K6_CONFIG=./config.json", "K6_USER_AGENT=foo"}
 
-	vus := NewSourceFromEnv(environ).From("K6_VUS")
-	pi := NewSourceFromEnv(environ).From("PI")
-	k6UserAgent := NewSourceFromEnv(environ).From("K6_USER_AGENT")
-	missed := NewSourceFromEnv(environ).From("MISSED")
+	source := NewSourceFromEnv(environ)
+	vus := source.From("K6_VUS")
+	pi := source.From("PI")
+	k6UserAgent := source.From("K6_USER_AGENT")
+	missed := source.From("MISSED")
 
-	withFixedBytesSizeFunc := func(bytesSize int) {
-		val, err := vus.BindFloatValue()(bytesSize)
-		expected := float64(6)
-		if err != nil {
-			t.Errorf("BindFloatValue error: %s", err)
-		}
-		if val != expected {
-			t.Errorf("BindFloatValue: got %f, expected %f", val, expected)
-		}
-
-		val, err = pi.BindFloatValue()(bytesSize)
-		expected = float64(3.14)
-		if err != nil {
-			t.Errorf("BindFloatValue error: %s", err)
-		}
-		// val != expected doesn't work
-		if (val-3.14) > 1e20 && (val-3.14) < -1e20 {
-			t.Errorf("BindFloatValue: got %f, expected %f", val, expected)
-		}
-
-		_, err = missed.BindFloatValue()(bytesSize)
-		if err == nil {
-			t.Error("BindFloatValue: expected field missing error")
-		}
-		if err.Error() != "field MISSED is missing in config source environment variables" {
-			t.Error("BindFloatValue: unexpected error message:", err)
-		}
-
-		_, err = k6UserAgent.BindFloatValue()(bytesSize)
-		if err == nil {
-			t.Error("BindFloatValue: expected syntax error")
-		}
-		if err.Error() != "BindFloatValue: parsing \"foo\": invalid syntax" {
-			t.Errorf("BindFloatValue: unexpected error message")
-		}
+	if err := source.Initialize(); err != nil {
+		t.Fatalf("received an unexpected init error %s", err)
 	}
 
-	intBytesSizes := []int{0, 8, 16, 32, 64}
+	var val float64
+	err := vus.BindFloatValueTo(&val)()
+	expected := float64(6)
+	if err != nil {
+		t.Errorf("BindFloatValue error: %s", err)
+	}
+	if val != expected {
+		t.Errorf("BindFloatValue: got %f, expected %f", val, expected)
+	}
 
-	for _, byteSize := range intBytesSizes {
-		withFixedBytesSizeFunc(byteSize)
+	err = pi.BindFloatValueTo(&val)()
+	expected = float64(3.14)
+	if err != nil {
+		t.Errorf("BindFloatValue error: %s", err)
+	}
+	if math.Abs(val-expected) > 1e20 { // val != expected doesn't work for floats
+		t.Errorf("BindFloatValue: got %f, expected %f", val, expected)
+	}
+
+	err = missed.BindFloatValueTo(&val)()
+	if err == nil {
+		t.Error("BindFloatValue: expected field missing error")
+	}
+	if err.Error() != "field MISSED is missing in config source environment variables" {
+		t.Error("BindFloatValue: unexpected error message:", err)
+	}
+
+	err = k6UserAgent.BindFloatValueTo(&val)()
+	if err == nil {
+		t.Error("BindFloatValue: expected syntax error")
+	}
+	if err.Error() != "BindFloatValue: parsing \"foo\": invalid syntax" {
+		t.Errorf("BindFloatValue: unexpected error message")
 	}
 }

--- a/source_json.go
+++ b/source_json.go
@@ -242,7 +242,7 @@ func (jba *jsonArrBinding) Len() int {
 	return len(jba.array)
 }
 
-func (jba *jsonArrBinding) Element(elNum int) LazySingleValueBinding {
+func (jba *jsonArrBinding) Element(elNum int) LazySingleValueBinder {
 	name := fmt.Sprintf("%s[%d]", jba.jb.name, elNum)
 	return &jsonBinding{
 		source: jba.jb.source,

--- a/source_json.go
+++ b/source_json.go
@@ -66,8 +66,17 @@ type jsonBinding struct {
 	name   string
 }
 
-func (jb *jsonBinding) GetSource() Source {
+var _ interface {
+	BindingFromSource
+	BindingWithName
+} = &envBinding{}
+
+func (jb *jsonBinding) Source() Source {
 	return jb.source
+}
+
+func (jb *jsonBinding) BoundName() string {
+	return jb.name
 }
 
 func (jb *jsonBinding) From(name string) *jsonBinding {

--- a/source_json.go
+++ b/source_json.go
@@ -106,48 +106,51 @@ func (jb *jsonBinding) BindStringValueTo(dest *string) func() error {
 	}
 }
 
-func (jb *jsonBinding) BindIntValue() func(bitSize int) (int64, error) {
-	return func(bitSize int) (int64, error) {
+func (jb *jsonBinding) BindIntValueTo(dest *int64) func() error {
+	return func() error {
 		raw, err := jb.lookup()
 		if err != nil {
 			// TODO: we might want to integrate custom error into lookup() method
-			return 0, NewBindFieldMissingError(jb.source.GetName(), jb.name)
+			return NewBindFieldMissingError(jb.source.GetName(), jb.name)
 		}
-		intVal, bindErr := parseInt(string(raw), 10, bitSize)
+		intVal, bindErr := parseInt(string(raw))
 		if bindErr != nil {
-			return 0, bindErr.withFuncName("BindIntValue")
+			return bindErr.withFuncName("BindIntValue")
 		}
-		return intVal, nil
+		*dest = intVal
+		return nil
 	}
 }
 
-func (jb *jsonBinding) BindUintValue() func(bitSize int) (uint64, error) {
-	return func(bitSize int) (uint64, error) {
+func (jb *jsonBinding) BindUintValueTo(dest *uint64) func() error {
+	return func() error {
 		raw, err := jb.lookup()
 		if err != nil {
 			// TODO: we might want to integrate custom error into lookup() method
-			return 0, NewBindFieldMissingError(jb.source.GetName(), jb.name)
+			return NewBindFieldMissingError(jb.source.GetName(), jb.name)
 		}
-		intVal, bindErr := parseUint(string(raw), 10, bitSize)
+		uintVal, bindErr := parseUint(string(raw))
 		if bindErr != nil {
-			return 0, bindErr.withFuncName("BindIntValue")
+			return bindErr.withFuncName("BindIntValue")
 		}
-		return intVal, nil
+		*dest = uintVal
+		return nil
 	}
 }
 
-func (jb *jsonBinding) BindFloatValue() func(bitSize int) (float64, error) {
-	return func(bitSize int) (float64, error) {
+func (jb *jsonBinding) BindFloatValueTo(dest *float64) func() error {
+	return func() error {
 		raw, err := jb.lookup()
 		if err != nil {
 			// TODO: we might want to integrate custom error into lookup() method
-			return 0, NewBindFieldMissingError(jb.source.GetName(), jb.name)
+			return NewBindFieldMissingError(jb.source.GetName(), jb.name)
 		}
-		intVal, bindErr := parseFloat(string(raw), bitSize)
+		floatVal, bindErr := parseFloat(string(raw))
 		if bindErr != nil {
-			return 0, bindErr.withFuncName("BindIntValue")
+			return bindErr.withFuncName("BindIntValue")
 		}
-		return intVal, nil
+		*dest = floatVal
+		return nil
 	}
 }
 

--- a/source_json_test.go
+++ b/source_json_test.go
@@ -19,7 +19,8 @@ func TestJSONBindIntValue(t *testing.T) {
 	}
 
 	var val int64
-	err := vus.BindIntValueTo(&val)()
+	valBinding := vus.BindIntValueTo(&val)
+	err := valBinding.Apply()
 	if err != nil {
 		t.Errorf("BindIntValue error: %s", err)
 	}
@@ -27,7 +28,8 @@ func TestJSONBindIntValue(t *testing.T) {
 		t.Errorf("BindIntValue: got %d, expected %d", val, expected)
 	}
 
-	err = missed.BindIntValueTo(&val)()
+	valBinding = missed.BindIntValueTo(&val)
+	err = valBinding.Apply()
 	if err == nil {
 		t.Error("BindIntValue: expected field missing error")
 	}
@@ -35,7 +37,8 @@ func TestJSONBindIntValue(t *testing.T) {
 		t.Error("BindIntValue: unexpected error message:", err)
 	}
 
-	err = k6UserAgent.BindIntValueTo(&val)()
+	valBinding = k6UserAgent.BindIntValueTo(&val)
+	err = valBinding.Apply()
 	if err == nil {
 		t.Error("BindIntValue: expected syntax error")
 	}
@@ -59,7 +62,8 @@ func TestJSONBindUintValue(t *testing.T) {
 	}
 
 	var val uint64
-	err := vus.BindUintValueTo(&val)()
+	valBinding := vus.BindUintValueTo(&val)
+	err := valBinding.Apply()
 	if err != nil {
 		t.Errorf("BindUintValueTo error: %s", err)
 	}
@@ -67,7 +71,8 @@ func TestJSONBindUintValue(t *testing.T) {
 		t.Errorf("BindUintValue: got %d, expected %d", val, expected)
 	}
 
-	err = missed.BindUintValueTo(&val)()
+	valBinding = missed.BindUintValueTo(&val)
+	err = valBinding.Apply()
 	if err == nil {
 		t.Error("BindUintValue: expected field k6_vus is missing error")
 	}
@@ -75,7 +80,8 @@ func TestJSONBindUintValue(t *testing.T) {
 		t.Error("BindUintValue: unexpected error message:", err)
 	}
 
-	err = k6UserAgent.BindUintValueTo(&val)()
+	valBinding = k6UserAgent.BindUintValueTo(&val)
+	err = valBinding.Apply()
 	if err == nil {
 		t.Error("BindUintValue: expected syntax error")
 	}
@@ -101,7 +107,8 @@ func TestJSONFloatValue(t *testing.T) {
 	}
 
 	var val float64
-	err := vus.BindFloatValueTo(&val)()
+	valBinding := vus.BindFloatValueTo(&val)
+	err := valBinding.Apply()
 	expected := float64(6)
 	if err != nil {
 		t.Errorf("BindFloatValue error: %s", err)
@@ -110,7 +117,8 @@ func TestJSONFloatValue(t *testing.T) {
 		t.Errorf("BindFloatValue: got %f, expected %f", val, expected)
 	}
 
-	err = pi.BindFloatValueTo(&val)()
+	valBinding = pi.BindFloatValueTo(&val)
+	err = valBinding.Apply()
 	expected = float64(3.14)
 	if err != nil {
 		t.Errorf("BindFloatValue error: %s", err)
@@ -119,7 +127,8 @@ func TestJSONFloatValue(t *testing.T) {
 		t.Errorf("BindFloatValue: got %f, expected %f", val, expected)
 	}
 
-	err = missed.BindFloatValueTo(&val)()
+	valBinding = missed.BindFloatValueTo(&val)
+	err = valBinding.Apply()
 	if err == nil {
 		t.Error("BindFloatValue: expected field missing error")
 	}
@@ -127,7 +136,8 @@ func TestJSONFloatValue(t *testing.T) {
 		t.Error("BindFloatValue: unexpected error message:", err)
 	}
 
-	err = k6UserAgent.BindFloatValueTo(&val)()
+	valBinding = k6UserAgent.BindFloatValueTo(&val)
+	err = valBinding.Apply()
 	if err == nil {
 		t.Error("BindFloatValue: expected syntax error")
 	}
@@ -151,7 +161,8 @@ func TestJSONBindIntValue__NestedJSON(t *testing.T) {
 	}
 
 	var val int64
-	err := vus.BindIntValueTo(&val)()
+	valBinding := vus.BindIntValueTo(&val)
+	err := valBinding.Apply()
 	if err != nil {
 		t.Errorf("BindIntValue error: %s", err)
 	}
@@ -159,7 +170,8 @@ func TestJSONBindIntValue__NestedJSON(t *testing.T) {
 		t.Errorf("BindIntValue: got %d, expected %d", val, expected)
 	}
 
-	err = missed.BindIntValueTo(&val)()
+	valBinding = missed.BindIntValueTo(&val)
+	err = valBinding.Apply()
 	if err == nil {
 		t.Error("BindIntValue: expected field missing error")
 	}
@@ -167,7 +179,8 @@ func TestJSONBindIntValue__NestedJSON(t *testing.T) {
 		t.Error("BindIntValue: unexpected error message:", err)
 	}
 
-	err = k6UserAgent.BindIntValueTo(&val)()
+	valBinding = k6UserAgent.BindIntValueTo(&val)
+	err = valBinding.Apply()
 	if err == nil {
 		t.Error("BindIntValue: expected syntax error")
 	}

--- a/source_json_test.go
+++ b/source_json_test.go
@@ -1,8 +1,12 @@
 package croconf
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestJSONBindIntValue(t *testing.T) {
+	t.Parallel()
 	json := []byte(`{"k6_vus":6,"pi":3.14,"k6_config":"./config.json","k6_user_agent":"foo"}`)
 
 	source := NewJSONSource(json)
@@ -11,45 +15,38 @@ func TestJSONBindIntValue(t *testing.T) {
 	missed := source.From("missed")
 
 	if err := source.Initialize(); err != nil {
-		t.Error(err)
+		t.Fatalf("received an unexpected init error %s", err)
 	}
 
-	withFixedBytesSizeFunc := func(bytesSize int) {
-		val, err := vus.BindIntValue()(bytesSize)
-		expected := int64(6)
-		if err != nil {
-			t.Errorf("BindIntValue error: %s", err)
-		}
-		if val != expected {
-			t.Errorf("BindIntValue: got %d, expected %d", val, expected)
-		}
-
-		_, err = missed.BindIntValue()(bytesSize)
-		if err == nil {
-			t.Error("BindIntValue: expected field missing error")
-		}
-		if err.Error() != "field missed is missing in config source json" {
-			t.Error("BindIntValue: unexpected error message:", err)
-		}
-
-		_, err = k6UserAgent.BindIntValue()(bytesSize)
-		if err == nil {
-			t.Error("BindIntValue: expected syntax error")
-		}
-		// TODO why are double quotes "\"foo"\"" ?
-		if err.Error() != `BindIntValue: parsing "\"foo\"": invalid syntax` {
-			t.Error("BindIntValue: unexpected error message:", err)
-		}
+	var val int64
+	err := vus.BindIntValueTo(&val)()
+	if err != nil {
+		t.Errorf("BindIntValue error: %s", err)
+	}
+	if expected := int64(6); val != expected {
+		t.Errorf("BindIntValue: got %d, expected %d", val, expected)
 	}
 
-	intBytesSizes := []int{0, 8, 16, 32, 64}
+	err = missed.BindIntValueTo(&val)()
+	if err == nil {
+		t.Error("BindIntValue: expected field missing error")
+	}
+	if err.Error() != "field missed is missing in config source json" {
+		t.Error("BindIntValue: unexpected error message:", err)
+	}
 
-	for _, byteSize := range intBytesSizes {
-		withFixedBytesSizeFunc(byteSize)
+	err = k6UserAgent.BindIntValueTo(&val)()
+	if err == nil {
+		t.Error("BindIntValue: expected syntax error")
+	}
+	// TODO why are double quotes "\"foo"\"" ?
+	if err.Error() != `BindIntValue: parsing "\"foo\"": invalid syntax` {
+		t.Error("BindIntValue: unexpected error message:", err)
 	}
 }
 
 func TestJSONBindUintValue(t *testing.T) {
+	t.Parallel()
 	json := []byte(`{"k6_vus":6,"pi":3.14,"k6_config":"./config.json","k6_user_agent":"foo"}`)
 
 	source := NewJSONSource(json)
@@ -58,45 +55,38 @@ func TestJSONBindUintValue(t *testing.T) {
 	missed := source.From("missed")
 
 	if err := source.Initialize(); err != nil {
-		t.Error(err)
+		t.Fatalf("received an unexpected init error %s", err)
 	}
 
-	withFixedBytesSizeFunc := func(bytesSize int) {
-		val, err := vus.BindUintValue()(bytesSize)
-		expected := uint64(6)
-		if err != nil {
-			t.Errorf("BindUintValueTo error: %s", err)
-		}
-		if val != expected {
-			t.Errorf("BindUintValue: got %d, expected %d", val, expected)
-		}
-
-		_, err = missed.BindUintValue()(bytesSize)
-		if err == nil {
-			t.Error("BindUintValue: expected field k6_vus is missing error")
-		}
-		if err.Error() != "field missed is missing in config source json" {
-			t.Error("BindUintValue: unexpected error message:", err)
-		}
-
-		_, err = k6UserAgent.BindUintValue()(bytesSize)
-		if err == nil {
-			t.Error("BindUintValue: expected syntax error")
-		}
-		// TODO why are double quotes "\"foo"\"" ?
-		if err.Error() != `BindIntValue: parsing "\"foo\"": invalid syntax` {
-			t.Error("BindIntValue: unexpected error message:", err)
-		}
+	var val uint64
+	err := vus.BindUintValueTo(&val)()
+	if err != nil {
+		t.Errorf("BindUintValueTo error: %s", err)
+	}
+	if expected := uint64(6); val != expected {
+		t.Errorf("BindUintValue: got %d, expected %d", val, expected)
 	}
 
-	intBytesSizes := []int{0, 8, 16, 32, 64}
+	err = missed.BindUintValueTo(&val)()
+	if err == nil {
+		t.Error("BindUintValue: expected field k6_vus is missing error")
+	}
+	if err.Error() != "field missed is missing in config source json" {
+		t.Error("BindUintValue: unexpected error message:", err)
+	}
 
-	for _, byteSize := range intBytesSizes {
-		withFixedBytesSizeFunc(byteSize)
+	err = k6UserAgent.BindUintValueTo(&val)()
+	if err == nil {
+		t.Error("BindUintValue: expected syntax error")
+	}
+	// TODO why are double quotes "\"foo"\"" ?
+	if err.Error() != `BindIntValue: parsing "\"foo\"": invalid syntax` {
+		t.Error("BindIntValue: unexpected error message:", err)
 	}
 }
 
 func TestJSONFloatValue(t *testing.T) {
+	t.Parallel()
 	json := []byte(`{"k6_vus":6,"pi":3.14,"k6_config":"./config.json","k6_user_agent":"foo"}`)
 
 	source := NewJSONSource(json)
@@ -107,55 +97,48 @@ func TestJSONFloatValue(t *testing.T) {
 	missed := source.From("missed")
 
 	if err := source.Initialize(); err != nil {
-		t.Error(err)
+		t.Fatalf("received an unexpected init error %s", err)
 	}
 
-	withFixedBytesSizeFunc := func(bytesSize int) {
-		val, err := vus.BindFloatValue()(bytesSize)
-		expected := float64(6)
-		if err != nil {
-			t.Errorf("BindFloatValue error: %s", err)
-		}
-		if val != expected {
-			t.Errorf("BindFloatValue: got %f, expected %f", val, expected)
-		}
-
-		val, err = pi.BindFloatValue()(bytesSize)
-		expected = float64(3.14)
-		if err != nil {
-			t.Errorf("BindFloatValue error: %s", err)
-		}
-		// val != expected doesn't work
-		if (val-3.14) > 1e20 && (val-3.14) < -1e20 {
-			t.Errorf("BindFloatValue: got %f, expected %f", val, expected)
-		}
-
-		_, err = missed.BindFloatValue()(bytesSize)
-		if err == nil {
-			t.Error("BindFloatValue: expected field missing error")
-		}
-		if err.Error() != "field missed is missing in config source json" {
-			t.Error("BindFloatValue: unexpected error message:", err)
-		}
-
-		_, err = k6UserAgent.BindFloatValue()(bytesSize)
-		if err == nil {
-			t.Error("BindFloatValue: expected syntax error")
-		}
-		// TODO why are double quotes "\"foo"\"" ?
-		if err.Error() != `BindIntValue: parsing "\"foo\"": invalid syntax` {
-			t.Error("BindIntValue: unexpected error message:", err)
-		}
+	var val float64
+	err := vus.BindFloatValueTo(&val)()
+	expected := float64(6)
+	if err != nil {
+		t.Errorf("BindFloatValue error: %s", err)
+	}
+	if val != expected {
+		t.Errorf("BindFloatValue: got %f, expected %f", val, expected)
 	}
 
-	intBytesSizes := []int{0, 8, 16, 32, 64}
+	err = pi.BindFloatValueTo(&val)()
+	expected = float64(3.14)
+	if err != nil {
+		t.Errorf("BindFloatValue error: %s", err)
+	}
+	if math.Abs(val-expected) > 1e20 { // val != expected doesn't work for floats
+		t.Errorf("BindFloatValue: got %f, expected %f", val, expected)
+	}
 
-	for _, byteSize := range intBytesSizes {
-		withFixedBytesSizeFunc(byteSize)
+	err = missed.BindFloatValueTo(&val)()
+	if err == nil {
+		t.Error("BindFloatValue: expected field missing error")
+	}
+	if err.Error() != "field missed is missing in config source json" {
+		t.Error("BindFloatValue: unexpected error message:", err)
+	}
+
+	err = k6UserAgent.BindFloatValueTo(&val)()
+	if err == nil {
+		t.Error("BindFloatValue: expected syntax error")
+	}
+	// TODO why are double quotes "\"foo"\"" ?
+	if err.Error() != `BindIntValue: parsing "\"foo\"": invalid syntax` {
+		t.Error("BindIntValue: unexpected error message:", err)
 	}
 }
 
 func TestJSONBindIntValue__NestedJSON(t *testing.T) {
+	t.Parallel()
 	json := []byte(`{"data":{"k6_vus":6,"pi":3.14,"k6_config":"./config.json","k6_user_agent":"foo"}}`)
 
 	source := NewJSONSource(json)
@@ -164,40 +147,32 @@ func TestJSONBindIntValue__NestedJSON(t *testing.T) {
 	missed := source.From("data").From("missed")
 
 	if err := source.Initialize(); err != nil {
-		t.Error(err)
+		t.Fatalf("received an unexpected init error %s", err)
 	}
 
-	withFixedBytesSizeFunc := func(bytesSize int) {
-		val, err := vus.BindIntValue()(bytesSize)
-		expected := int64(6)
-		if err != nil {
-			t.Errorf("BindIntValue error: %s", err)
-		}
-		if val != expected {
-			t.Errorf("BindIntValue: got %d, expected %d", val, expected)
-		}
-
-		_, err = missed.BindIntValue()(bytesSize)
-		if err == nil {
-			t.Error("BindIntValue: expected field missing error")
-		}
-		if err.Error() != "field data.missed is missing in config source json" {
-			t.Error("BindIntValue: unexpected error message:", err)
-		}
-
-		_, err = k6UserAgent.BindIntValue()(bytesSize)
-		if err == nil {
-			t.Error("BindIntValue: expected syntax error")
-		}
-		// TODO why are double quotes "\"foo"\"" ?
-		if err.Error() != `BindIntValue: parsing "\"foo\"": invalid syntax` {
-			t.Error("BindIntValue: unexpected error message:", err)
-		}
+	var val int64
+	err := vus.BindIntValueTo(&val)()
+	if err != nil {
+		t.Errorf("BindIntValue error: %s", err)
+	}
+	if expected := int64(6); val != expected {
+		t.Errorf("BindIntValue: got %d, expected %d", val, expected)
 	}
 
-	intBytesSizes := []int{0, 8, 16, 32, 64}
+	err = missed.BindIntValueTo(&val)()
+	if err == nil {
+		t.Error("BindIntValue: expected field missing error")
+	}
+	if err.Error() != "field data.missed is missing in config source json" {
+		t.Error("BindIntValue: unexpected error message:", err)
+	}
 
-	for _, byteSize := range intBytesSizes {
-		withFixedBytesSizeFunc(byteSize)
+	err = k6UserAgent.BindIntValueTo(&val)()
+	if err == nil {
+		t.Error("BindIntValue: expected syntax error")
+	}
+	// TODO why are double quotes "\"foo"\"" ?
+	if err.Error() != `BindIntValue: parsing "\"foo\"": invalid syntax` {
+		t.Error("BindIntValue: unexpected error message:", err)
 	}
 }

--- a/types.go
+++ b/types.go
@@ -40,22 +40,22 @@ type Array interface { // TODO: rename to List and ListBinding?
 
 type StringValueBinding interface {
 	SourceGetter
-	BindStringValueTo(dest *string) func() error
+	BindStringValueTo(*string) func() error
 }
 
 type IntValueBinding interface {
 	SourceGetter
-	BindIntValue() func(bitSize int) (int64, error)
+	BindIntValueTo(*int64) func() error
 }
 
 type UintValueBinding interface {
 	SourceGetter
-	BindUintValue() func(bitSize int) (uint64, error)
+	BindUintValueTo(*uint64) func() error
 }
 
 type FloatValueBinding interface {
 	SourceGetter
-	BindFloatValue() func(bitSize int) (float64, error)
+	BindFloatValueTo(*float64) func() error
 }
 
 type BoolValueBinding interface {

--- a/types.go
+++ b/types.go
@@ -14,12 +14,21 @@ type Source interface {
 	GetName() string
 }
 
-type SourceGetter interface {
-	GetSource() Source
+type Binding interface {
+	Apply() error
+}
+
+type BindingFromSource interface {
+	// Binding
+	Source() Source
+}
+
+type BindingWithName interface {
+	// Binding
+	BoundName() string
 }
 
 type LazySingleValueBinding interface {
-	SourceGetter
 	StringValueBinding
 	IntValueBinding
 	UintValueBinding
@@ -29,7 +38,6 @@ type LazySingleValueBinding interface {
 }
 
 type ArrayBinding interface {
-	SourceGetter
 	BindArray() func() (Array, error)
 }
 
@@ -39,36 +47,29 @@ type Array interface { // TODO: rename to List and ListBinding?
 }
 
 type StringValueBinding interface {
-	SourceGetter
 	BindStringValueTo(*string) func() error
 }
 
 type IntValueBinding interface {
-	SourceGetter
 	BindIntValueTo(*int64) func() error
 }
 
 type UintValueBinding interface {
-	SourceGetter
 	BindUintValueTo(*uint64) func() error
 }
 
 type FloatValueBinding interface {
-	SourceGetter
 	BindFloatValueTo(*float64) func() error
 }
 
 type BoolValueBinding interface {
-	SourceGetter
 	BindBoolValueTo(dest *bool) func() error
 }
 
 type TextBasedValueBinding interface {
-	SourceGetter
 	BindTextBasedValueTo(dest encoding.TextUnmarshaler) func() error
 }
 
 type CustomValueBinding interface {
-	SourceGetter
 	BindValue() func() error
 }

--- a/types.go
+++ b/types.go
@@ -28,48 +28,48 @@ type BindingWithName interface {
 	BoundName() string
 }
 
-type LazySingleValueBinding interface {
-	StringValueBinding
-	IntValueBinding
-	UintValueBinding
-	FloatValueBinding
-	BoolValueBinding
-	TextBasedValueBinding
+type LazySingleValueBinder interface {
+	StringValueBinder
+	IntValueBinder
+	UintValueBinder
+	FloatValueBinder
+	BoolValueBinder
+	TextBasedValueBinder
 }
 
-type ArrayBinding interface {
+type ArrayBinder interface {
 	BindArray() func() (Array, error)
 }
 
 type Array interface { // TODO: rename to List and ListBinding?
 	Len() int
-	Element(int) LazySingleValueBinding
+	Element(int) LazySingleValueBinder
 }
 
-type StringValueBinding interface {
+type StringValueBinder interface {
 	BindStringValueTo(*string) func() error
 }
 
-type IntValueBinding interface {
+type IntValueBinder interface {
 	BindIntValueTo(*int64) func() error
 }
 
-type UintValueBinding interface {
+type UintValueBinder interface {
 	BindUintValueTo(*uint64) func() error
 }
 
-type FloatValueBinding interface {
+type FloatValueBinder interface {
 	BindFloatValueTo(*float64) func() error
 }
 
-type BoolValueBinding interface {
+type BoolValueBinder interface {
 	BindBoolValueTo(dest *bool) func() error
 }
 
-type TextBasedValueBinding interface {
+type TextBasedValueBinder interface {
 	BindTextBasedValueTo(dest encoding.TextUnmarshaler) func() error
 }
 
-type CustomValueBinding interface {
+type CustomValueBinder interface {
 	BindValue() func() error
 }

--- a/types.go
+++ b/types.go
@@ -3,15 +3,13 @@ package croconf
 import "encoding"
 
 type Field interface {
-	Consolidate() []error
-	ValueSource() Source // nil for default value
 	Destination() interface{}
+	Bindings() []Binding
 }
 
 type Source interface {
 	Initialize() error
-	// TODO: figure out what to put here? and if we even need this :/
-	GetName() string
+	GetName() string // TODO: remove?
 }
 
 type Binding interface {
@@ -19,12 +17,8 @@ type Binding interface {
 }
 
 type BindingFromSource interface {
-	// Binding
+	Binding
 	Source() Source
-}
-
-type BindingWithName interface {
-	// Binding
 	BoundName() string
 }
 
@@ -37,39 +31,35 @@ type LazySingleValueBinder interface {
 	TextBasedValueBinder
 }
 
-type ArrayBinder interface {
-	BindArray() func() (Array, error)
-}
-
-type Array interface { // TODO: rename to List and ListBinding?
-	Len() int
-	Element(int) LazySingleValueBinder
-}
-
 type StringValueBinder interface {
-	BindStringValueTo(*string) func() error
+	BindStringValueTo(*string) Binding
 }
 
 type IntValueBinder interface {
-	BindIntValueTo(*int64) func() error
+	BindIntValueTo(*int64) Binding
 }
 
 type UintValueBinder interface {
-	BindUintValueTo(*uint64) func() error
+	BindUintValueTo(*uint64) Binding
 }
 
 type FloatValueBinder interface {
-	BindFloatValueTo(*float64) func() error
+	BindFloatValueTo(*float64) Binding
 }
 
 type BoolValueBinder interface {
-	BindBoolValueTo(dest *bool) func() error
+	BindBoolValueTo(dest *bool) Binding
 }
 
 type TextBasedValueBinder interface {
-	BindTextBasedValueTo(dest encoding.TextUnmarshaler) func() error
+	BindTextBasedValueTo(dest encoding.TextUnmarshaler) Binding
 }
 
 type CustomValueBinder interface {
-	BindValue() func() error
+	BindValue() Binding
+}
+
+// TODO: rename to List or Slice instead of Array?
+type ArrayValueBinder interface {
+	BindArrayValueTo(length *int, element *func(int) LazySingleValueBinder) Binding
 }

--- a/utils.go
+++ b/utils.go
@@ -1,25 +1,45 @@
 package croconf
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
 
-func parseInt(s string, base int, bitSize int) (int64, *BindValueError) {
-	val, err := strconv.ParseInt(s, base, bitSize)
+func checkIntBitsize(val int64, bitSize int) error {
+	// See MinInt and MaxInt values in https://golang.org/pkg/math/#pkg-constants
+	min, max := int64(-1<<(bitSize-1)), int64(1<<(bitSize-1)-1)
+	if val < min || val > max {
+		return fmt.Errorf("invalid value %d, it must be between %d and %d", val, min, max)
+	}
+	return nil
+}
+
+func checkUintBitsize(val uint64, bitSize int) error {
+	// See MaxUint values in https://golang.org/pkg/math/#pkg-constants
+	if max := uint64(1<<bitSize - 1); val > max {
+		return fmt.Errorf("invalid value %d, it must be between 0 and %d", val, max)
+	}
+	return nil
+}
+
+func parseInt(s string) (int64, *BindValueError) {
+	val, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
 		return 0, NewBindValueError("parseInt", s, err)
 	}
 	return val, nil
 }
 
-func parseUint(s string, base int, bitSize int) (uint64, *BindValueError) {
-	val, err := strconv.ParseUint(s, base, bitSize)
+func parseUint(s string) (uint64, *BindValueError) {
+	val, err := strconv.ParseUint(s, 10, 64)
 	if err != nil {
 		return 0, NewBindValueError("parseUint", s, err)
 	}
 	return val, nil
 }
 
-func parseFloat(s string, bitSize int) (float64, *BindValueError) {
-	val, err := strconv.ParseFloat(s, bitSize)
+func parseFloat(s string) (float64, *BindValueError) {
+	val, err := strconv.ParseFloat(s, 64)
 	if err != nil {
 		return 0, NewBindValueError("parseFloat", s, err)
 	}


### PR DESCRIPTION
It will probably be easier to read this commit by commit... :sweat_smile: 

The biggest change is that now we now have a clear difference in the `Binding` (the callback that reads some source (or other) value and saves it to the `Destination`) and the `Binder` (the thing that creates the `Binding`). Array and number bindings are now also very similar to the other simpler bindings :tada: The `bitSize` checking is now only done on the frontend side, sources are no longer concerned with it (because they don't need to be) :tada: 

I still want to tweak things things (potentially how default values are handled) and add more fields (esp. if I can reduce the boilerplate), so I may push a few more commits here... :sweat_smile: 
